### PR TITLE
wip #5 Remove initialSize, add growIdle

### DIFF
--- a/src/main/java/reactor/pool/AbstractPool.java
+++ b/src/main/java/reactor/pool/AbstractPool.java
@@ -329,6 +329,7 @@ abstract class AbstractPool<POOLABLE> implements Pool<POOLABLE> {
             }
             PoolMetricsRecorder metricsRecorder = pool.poolConfig.metricsRecorder;
             metricsRecorder.recordAllocationSuccessAndLatency(metricsRecorder.measureTime(startTime));
+            pool.drain();
         }
 
         @Override
@@ -346,8 +347,6 @@ abstract class AbstractPool<POOLABLE> implements Pool<POOLABLE> {
 
             actual.onNext(seenOnTerminate);
             actual.onComplete();
-
-            pool.drain();
         }
 
         @Override
@@ -367,8 +366,6 @@ abstract class AbstractPool<POOLABLE> implements Pool<POOLABLE> {
             PoolMetricsRecorder metricsRecorder = pool.poolConfig.metricsRecorder;
             metricsRecorder.recordAllocationFailureAndLatency(metricsRecorder.measureTime(startTime));
             actual.onError(t);
-
-            pool.drain();
         }
 
         @Override

--- a/src/main/java/reactor/pool/AffinityPool.java
+++ b/src/main/java/reactor/pool/AffinityPool.java
@@ -140,11 +140,11 @@ final class AffinityPool<POOLABLE> extends AbstractPool<POOLABLE> {
         SubPool<POOLABLE> subPool = pools.get(Thread.currentThread().getId());
         if (subPool == null || !subPool.tryDirectRecycle(pooledRef)) {
             availableElements.offer(pooledRef);
-            slowPathRecycle();
+            drain();
         }
     }
 
-    void slowPathRecycle() {
+    void drain() {
         if (SLOWPATH_WIP.getAndIncrement(this) != 0) {
             return;
         }

--- a/src/main/java/reactor/pool/Pool.java
+++ b/src/main/java/reactor/pool/Pool.java
@@ -77,4 +77,5 @@ public interface Pool<POOLABLE> extends Disposable {
                 PooledRef::release);
     }
 
+    Mono<Integer> growIdle(int desired);
 }

--- a/src/main/java/reactor/pool/PoolBuilder.java
+++ b/src/main/java/reactor/pool/PoolBuilder.java
@@ -52,7 +52,6 @@ public class PoolBuilder<T> {
     final Mono<T> allocator;
 
     boolean                 isThreadAffinity     = true;
-    int                     initialSize          = 0;
     AllocationStrategy      allocationStrategy   = AllocationStrategies.UNBOUNDED;
     Function<T, Mono<Void>> releaseHandler       = noopHandler();
     Function<T, Mono<Void>> destroyHandler       = noopHandler();
@@ -75,23 +74,6 @@ public class PoolBuilder<T> {
      */
     public PoolBuilder<T> threadAffinity(boolean isThreadAffinity) {
         this.isThreadAffinity = isThreadAffinity;
-        return this;
-    }
-
-    /**
-     * How many resources the {@link Pool} should allocate upon creation.
-     * This parameter MAY be ignored by some implementations (although they should state so in their documentation).
-     * <p>
-     * Defaults to {@code 0}.
-     *
-     * @param n the initial size of the {@link Pool}.
-     * @return this {@link Pool} builder
-     */
-    public PoolBuilder<T> initialSize(int n) {
-        if (n < 0) {
-            throw new IllegalArgumentException("initialSize must be >= 0");
-        }
-        this.initialSize = n;
         return this;
     }
 
@@ -239,7 +221,7 @@ public class PoolBuilder<T> {
 
     //kept package-private for the benefit of tests
     AbstractPool.DefaultPoolConfig<T> buildConfig() {
-        return new AbstractPool.DefaultPoolConfig<>(allocator, initialSize, allocationStrategy,
+        return new AbstractPool.DefaultPoolConfig<>(allocator, allocationStrategy,
                 releaseHandler,
                 destroyHandler,
                 evictionPredicate,

--- a/src/main/java/reactor/pool/SimplePool.java
+++ b/src/main/java/reactor/pool/SimplePool.java
@@ -72,20 +72,6 @@ abstract class SimplePool<POOLABLE> extends AbstractPool<POOLABLE> {
         else {
             this.elements = new MpscArrayQueue<>(Math.max(2, maxSize));
         }
-
-        int initSize = poolConfig.allocationStrategy.getPermits(poolConfig.initialSize);
-        for (int i = 0; i < initSize; i++) {
-            long start = metricsRecorder.now();
-            try {
-                POOLABLE poolable = Objects.requireNonNull(poolConfig.allocator.block(), "allocator returned null in constructor");
-                metricsRecorder.recordAllocationSuccessAndLatency(metricsRecorder.measureTime(start));
-                elements.offer(new QueuePooledRef<>(this, poolable)); //the pool slot won't access this pool instance until after it has been constructed
-            }
-            catch (Throwable e) {
-                metricsRecorder.recordAllocationFailureAndLatency(metricsRecorder.measureTime(start));
-                throw e;
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
@nebhale @smaldini I wonder if the API should allow for "batches" or if it should simply invoke the allocator once and wrap that call with correct metrics housekeeping + allocation permit check.