### PR TITLE
Add InstrumentedPool notion and gauge-compatible metrics API

### DIFF
--- a/src/main/java/reactor/pool/AbstractPool.java
+++ b/src/main/java/reactor/pool/AbstractPool.java
@@ -44,7 +44,7 @@ import reactor.util.context.Context;
  * @author Simon Baslé
  */
 abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
-                                                 InstrumentedPool.PoolIntrospection {
+                                                 InstrumentedPool.PoolMetrics {
 
     //A pool should be rare enough that having instance loggers should be ok
     //This helps with testability of some methods that for now mainly log
@@ -66,26 +66,26 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
     // == pool introspection methods ==
 
     @Override
-    public PoolMetricsRecorder metricsRecorder() {
-        return metricsRecorder;
-    }
-
-    @Override
-    public PoolIntrospection introspect() {
+    public PoolMetrics metrics() {
         return this;
     }
 
     @Override
-    public int pendingSize() {
+    public int pendingAcquireSize() {
         return PENDING_COUNT.get(this);
+    }
+
+    @Override
+    public int allocatedSize() {
+        return poolConfig.allocationStrategy.permitGranted();
     }
 
     @Override
     abstract public int idleSize();
 
     @Override
-    public int allocatedSize() {
-        return poolConfig.allocationStrategy.permitGranted();
+    public int acquiredSize() {
+        return allocatedSize() - idleSize();
     }
 
     @Override
@@ -94,7 +94,7 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
     }
 
     @Override
-    public int getMaxPendingSize() {
+    public int getMaxPendingAcquireSize() {
         return poolConfig.maxPending < 0 ? Integer.MAX_VALUE : poolConfig.maxPending;
     }
 

--- a/src/main/java/reactor/pool/AffinityPool.java
+++ b/src/main/java/reactor/pool/AffinityPool.java
@@ -129,7 +129,7 @@ final class AffinityPool<POOLABLE> extends AbstractPool<POOLABLE> {
     }
 
     @Override
-    int idleSize() {
+    public int idleSize() {
         return availableElements.size();
     }
 

--- a/src/main/java/reactor/pool/AllocationStrategy.java
+++ b/src/main/java/reactor/pool/AllocationStrategy.java
@@ -44,6 +44,16 @@ public interface AllocationStrategy {
     int estimatePermitCount();
 
     /**
+     * @return the maximum number of permits this strategy can grant in total, or {@link Integer#MAX_VALUE} for unbounded.
+     */
+    int permitMaximum();
+
+    /**
+     * @return a best estimate of the number of permits currently granted, between 0 and {@link Integer#MAX_VALUE}
+     */
+    int permitGranted();
+
+    /**
      * Update the strategy to indicate that N resources were discarded from the {@link Pool}, potentially leaving space
      * for N new ones to be allocated. Users MUST ensure that this method isn't called with a value greater than the
      * number of held permits it has.

--- a/src/main/java/reactor/pool/InstrumentedPool.java
+++ b/src/main/java/reactor/pool/InstrumentedPool.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool;
+
+/**
+ * An {@link InstrumentedPool} is a {@link Pool} that exposes a few additional methods
+ * around metrics.
+ *
+ * @author Simon Baslé
+ */
+public interface InstrumentedPool<POOLABLE> extends Pool<POOLABLE> {
+
+	/**
+	 * @return a {@link PoolIntrospection} object to be used to get live gauges about the {@link Pool}
+	 */
+	PoolIntrospection introspect();
+
+	/**
+	 * @return a {@link PoolMetricsRecorder} that is used by the {@link Pool} to record timing metrics.
+	 */
+	PoolMetricsRecorder metricsRecorder();
+
+	/**
+	 * An object that can be used to get live information about a {@link Pool}, suitable
+	 * for gauge metrics.
+	 * <p>
+	 * getXxx methods are configuration accessors, ie values that won't change over time,
+	 * whereas other methods can be used as gauges to introspect the current state of the
+	 * pool.
+	 */
+	interface PoolIntrospection {
+
+		/**
+		 * Measure the current number of "pending" {@link Pool#acquire() acquire Monos} in
+		 * the {@link Pool}.
+		 * <p>
+		 * An acquire is in the pending state when it is attempted at a point when no idle
+		 * resource is available in the pool, and no new resource can be created.
+		 *
+		 * @return the number of pending acquire
+		 */
+		int pendingSize();
+
+		/**
+		 * Measure the current number of idle resources in the {@link Pool}.
+		 * <p>
+		 * Note that some resources might be lazily evicted when they're next considered
+		 * for an incoming {@link Pool#acquire()} call. Such resources would still count
+		 * towards this method.
+		 *
+		 * @return the number of idle resources
+		 */
+		int idleSize();
+
+		/**
+		 * Measure the current number of allocated resources in the {@link Pool}, acquired
+		 * or idle.
+		 *
+		 * @return the total number of allocated resources managed by the {@link Pool}
+		 */
+		int allocatedSize();
+
+		/**
+		 * Get the maximum number of live resources this {@link Pool} will allow.
+		 * <p>
+		 * A {@link Pool} might be unbounded, in which case this method returns {@link Integer#MAX_VALUE}.
+		 *
+		 * @return the maximum number of live resources that can be allocated by this {@link Pool}.
+		 */
+		int getMaxAllocatedSize();
+
+		/**
+		 * Get the maximum number of {@link Pool#acquire()} this {@link Pool} can queue in
+		 * a pending state when no available resource is immediately handy (and the {@link Pool}
+		 * cannot allocate more resources).
+		 * <p>
+		 * A {@link Pool} pending queue might be unbounded, in which case this method returns
+		 * {@link Integer#MAX_VALUE}.
+		 *
+		 * @return the maximum number of pending acquire that can be enqueued by this {@link Pool}.
+		 */
+		int getMaxPendingSize();
+	}
+}

--- a/src/main/java/reactor/pool/InstrumentedPool.java
+++ b/src/main/java/reactor/pool/InstrumentedPool.java
@@ -25,14 +25,9 @@ package reactor.pool;
 public interface InstrumentedPool<POOLABLE> extends Pool<POOLABLE> {
 
 	/**
-	 * @return a {@link PoolIntrospection} object to be used to get live gauges about the {@link Pool}
+	 * @return a {@link PoolMetrics} object to be used to get live gauges about the {@link Pool}
 	 */
-	PoolIntrospection introspect();
-
-	/**
-	 * @return a {@link PoolMetricsRecorder} that is used by the {@link Pool} to record timing metrics.
-	 */
-	PoolMetricsRecorder metricsRecorder();
+	PoolMetrics metrics();
 
 	/**
 	 * An object that can be used to get live information about a {@link Pool}, suitable
@@ -42,18 +37,15 @@ public interface InstrumentedPool<POOLABLE> extends Pool<POOLABLE> {
 	 * whereas other methods can be used as gauges to introspect the current state of the
 	 * pool.
 	 */
-	interface PoolIntrospection {
+	interface PoolMetrics {
 
 		/**
-		 * Measure the current number of "pending" {@link Pool#acquire() acquire Monos} in
-		 * the {@link Pool}.
-		 * <p>
-		 * An acquire is in the pending state when it is attempted at a point when no idle
-		 * resource is available in the pool, and no new resource can be created.
+		 * Measure the current number of allocated resources in the {@link Pool}, acquired
+		 * or idle.
 		 *
-		 * @return the number of pending acquire
+		 * @return the total number of allocated resources managed by the {@link Pool}
 		 */
-		int pendingSize();
+		int allocatedSize();
 
 		/**
 		 * Measure the current number of idle resources in the {@link Pool}.
@@ -67,12 +59,23 @@ public interface InstrumentedPool<POOLABLE> extends Pool<POOLABLE> {
 		int idleSize();
 
 		/**
-		 * Measure the current number of allocated resources in the {@link Pool}, acquired
-		 * or idle.
+		 * Measure the current number of resources that have been successfully
+		 * {@link Pool#acquire() acquired} and are in active use.
 		 *
-		 * @return the total number of allocated resources managed by the {@link Pool}
+		 * @return the number of acquired resources
 		 */
-		int allocatedSize();
+		int acquiredSize();
+
+		/**
+		 * Measure the current number of "pending" {@link Pool#acquire() acquire Monos} in
+		 * the {@link Pool}.
+		 * <p>
+		 * An acquire is in the pending state when it is attempted at a point when no idle
+		 * resource is available in the pool, and no new resource can be created.
+		 *
+		 * @return the number of pending acquire
+		 */
+		int pendingAcquireSize();
 
 		/**
 		 * Get the maximum number of live resources this {@link Pool} will allow.
@@ -93,6 +96,6 @@ public interface InstrumentedPool<POOLABLE> extends Pool<POOLABLE> {
 		 *
 		 * @return the maximum number of pending acquire that can be enqueued by this {@link Pool}.
 		 */
-		int getMaxPendingSize();
+		int getMaxPendingAcquireSize();
 	}
 }

--- a/src/main/java/reactor/pool/PoolBuilder.java
+++ b/src/main/java/reactor/pool/PoolBuilder.java
@@ -57,12 +57,11 @@ public class PoolBuilder<T> {
     }
 
     final Mono<T> allocator;
-
     boolean                                isThreadAffinity     = true;
     boolean                                isLifo               = false;
     int                                    initialSize          = 0;
     int                                    maxPending           = -1;
-    AllocationStrategy                     allocationStrategy   = AllocationStrategies.UNBOUNDED;
+    AllocationStrategy                     allocationStrategy   = null;
     Function<T, ? extends Publisher<Void>> releaseHandler       = noopHandler();
     Function<T, ? extends Publisher<Void>> destroyHandler       = noopHandler();
     BiPredicate<T, PooledRefMetadata>      evictionPredicate    = neverPredicate();
@@ -185,7 +184,7 @@ public class PoolBuilder<T> {
      * @return this {@link Pool} builder
 	 */
 	public PoolBuilder<T> sizeUnbounded() {
-		return allocationStrategy(AllocationStrategies.UNBOUNDED);
+		return allocationStrategy(new AllocationStrategies.UnboundedAllocationStrategy());
 	}
 
     /**
@@ -298,7 +297,7 @@ public class PoolBuilder<T> {
     AbstractPool.DefaultPoolConfig<T> buildConfig() {
         return new AbstractPool.DefaultPoolConfig<>(allocator,
                 initialSize,
-                allocationStrategy,
+                allocationStrategy == null ? new AllocationStrategies.UnboundedAllocationStrategy() : allocationStrategy,
                 maxPending,
                 releaseHandler,
                 destroyHandler,

--- a/src/main/java/reactor/pool/SimplePool.java
+++ b/src/main/java/reactor/pool/SimplePool.java
@@ -120,7 +120,7 @@ abstract class SimplePool<POOLABLE> extends AbstractPool<POOLABLE> {
     }
 
     @Override
-    int idleSize() {
+    public int idleSize() {
         return elements.size();
     }
 

--- a/src/test/java/reactor/pool/AllocationStrategiesTest.java
+++ b/src/test/java/reactor/pool/AllocationStrategiesTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import reactor.pool.AllocationStrategies.SizeBasedAllocationStrategy;
+import reactor.pool.AllocationStrategies.UnboundedAllocationStrategy;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 
@@ -257,14 +258,14 @@ class AllocationStrategiesTest {
 
         @Test
         void permitCountIsMaxValue() {
-            AllocationStrategy test = AllocationStrategies.UNBOUNDED;
+            AllocationStrategy test = new UnboundedAllocationStrategy();
 
             assertThat(test.estimatePermitCount()).isEqualTo(Integer.MAX_VALUE);
         }
 
         @Test
         void getPermitsDoesntChangeCount() {
-            AllocationStrategy test = AllocationStrategies.UNBOUNDED;
+            AllocationStrategy test = new UnboundedAllocationStrategy();
 
             assertThat(test.getPermits(100)).as("first try").isEqualTo(100);
             assertThat(test.getPermits(1000)).as("second try").isEqualTo(1000);
@@ -273,21 +274,21 @@ class AllocationStrategiesTest {
 
         @Test
         void getPermitDesiredZero() {
-            AllocationStrategy test = AllocationStrategies.UNBOUNDED;
+            AllocationStrategy test = new UnboundedAllocationStrategy();
 
             assertThat(test.getPermits(0)).isZero();
         }
 
         @Test
         void getPermitDesiredNegative() {
-            AllocationStrategy test = AllocationStrategies.UNBOUNDED;
+            AllocationStrategy test = new UnboundedAllocationStrategy();
 
             assertThat(test.getPermits(-1)).isZero();
         }
 
         @Test
         void returnPermitsDoesntChangeMax() {
-            final AllocationStrategy test = AllocationStrategies.UNBOUNDED;
+            final AllocationStrategy test = new UnboundedAllocationStrategy();
 
             test.returnPermits(1000);
 


### PR DESCRIPTION
The idea in this PR is to expose internal state of the pool through a PoolMetrics API (similar to what is done with PooledRef, a view of the Pool).

It also exposes 2 configuration elements (max size and max pending size).

Fixes #22 