### PR TITLE
Ensure metrics are accurate when PooledRef#release onComplete event is sent

### DIFF
--- a/src/main/java/reactor/pool/AffinityPool.java
+++ b/src/main/java/reactor/pool/AffinityPool.java
@@ -524,8 +524,6 @@ final class AffinityPool<POOLABLE> extends AbstractPool<POOLABLE> {
                 return;
             }
 
-            actual.onComplete();
-
             if (!pool.poolConfig.evictionPredicate.test(slot.poolable, slot)) {
                 pool.recycle(slot);
             }
@@ -535,6 +533,8 @@ final class AffinityPool<POOLABLE> extends AbstractPool<POOLABLE> {
                 //simplified version of what we do in doAcquire, with the caveat that we don't try to create a SubPool
                 pool.bestEffortAllocateOrPend();
             }
+
+            actual.onComplete();
         }
 
         @Override


### PR DESCRIPTION
If one tries to obtain the metrics like the code below, they are not accurate (e.g. `acquired=1` and `idle=0`)

```
PooledRef.release
         .subscribe(null, null, () -> {
             pool.metrics().acquiredSize()
             pool.metrics().idleSize()
         })
```