### PR TITLE
fix #40 run drain loop after invalidation to check pending

### DIFF
--- a/src/main/java/reactor/pool/AffinityPool.java
+++ b/src/main/java/reactor/pool/AffinityPool.java
@@ -461,7 +461,7 @@ final class AffinityPool<POOLABLE> extends AbstractPool<POOLABLE> {
 
         @Override
         public Mono<Void> invalidate() {
-            return pool.destroyPoolable(this);
+            return pool.destroyPoolable(this).then(Mono.fromRunnable(pool::bestEffortAllocateOrPend));
         }
     }
 

--- a/src/main/java/reactor/pool/SimplePool.java
+++ b/src/main/java/reactor/pool/SimplePool.java
@@ -253,7 +253,7 @@ abstract class SimplePool<POOLABLE> extends AbstractPool<POOLABLE> {
             return Mono.defer(() -> {
                 //immediately clean up state
                 ACQUIRED.decrementAndGet(pool);
-                return pool.destroyPoolable(this);
+                return pool.destroyPoolable(this).then(Mono.fromRunnable(pool::drain));
             });
         }
     }


### PR DESCRIPTION
Especially when fixed, invalidation needs to check for pending acquire.
Not doing it might prevent any further allocation.