### PR TITLE
Switch to MPMC queues for pendings and remove JCTools

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,6 @@ ext {
   gradleScriptDir = "${rootProject.projectDir}/gradle"
 
   reactorBOM = "Californium-SR6"
-  jcToolsVersion = "2.1.1"
   hdrHistogramVersion = "2.1.11"
 
   // Languages
@@ -176,8 +175,6 @@ configure(rootProject) { project ->
 
   dependencies {
     compile "io.projectreactor:reactor-core"
-
-    compile "org.jctools:jctools-core:$jcToolsVersion"
 
     // JSR-305 annotations
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"

--- a/src/main/java/reactor/pool/AffinityPool.java
+++ b/src/main/java/reactor/pool/AffinityPool.java
@@ -351,11 +351,13 @@ final class AffinityPool<POOLABLE> extends AbstractPool<POOLABLE> {
 
     static final class FifoSubPool<POOLABLE> extends SubPool<POOLABLE> {
 
-        final Queue<Borrower<POOLABLE>> localPendings; //needs to be MPSC. Producer: any thread that doAcquire. Consumer: whomever has the LOCKED.
+        //needs to be MPMC. Producer: any thread that doAcquire. Consumer: whomever has the LOCKED + remove.
+        final Queue<Borrower<POOLABLE>> localPendings;
 
         FifoSubPool(AffinityPool<POOLABLE> parent) {
             super(parent);
-            this.localPendings = new MpscLinkedQueue8<>();
+            //unbounded MPMC with remove capacity
+            this.localPendings = new ConcurrentLinkedQueue<>();
         }
 
         @Override

--- a/src/main/java/reactor/pool/SimpleFifoPool.java
+++ b/src/main/java/reactor/pool/SimpleFifoPool.java
@@ -16,14 +16,13 @@
 package reactor.pool;
 
 import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-
-import org.jctools.queues.MpscLinkedQueue8;
 
 import reactor.util.concurrent.Queues;
 
 /**
- * This implementation is based on MPSC queues for both idle resources and pending {@link Pool#acquire()} Monos,
+ * This implementation is based on MPMC queues for both idle resources and pending {@link Pool#acquire()} Monos,
  * resulting in serving pending borrowers in FIFO order.
  *
  * See {@link SimplePool} for other characteristics of the simple pool.
@@ -40,7 +39,7 @@ final class SimpleFifoPool<POOLABLE> extends SimplePool<POOLABLE> {
 
     public SimpleFifoPool(DefaultPoolConfig<POOLABLE> poolConfig) {
         super(poolConfig);
-        this.pending = new MpscLinkedQueue8<>(); //unbounded MPSC
+        this.pending = new ConcurrentLinkedQueue<>(); //unbounded MPMC
     }
 
     @Override

--- a/src/main/java/reactor/pool/SimpleLifoPool.java
+++ b/src/main/java/reactor/pool/SimpleLifoPool.java
@@ -21,8 +21,9 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 /**
- * This implementation is based on MPSC queues for idle resources and a {@link ConcurrentLinkedDeque}
- * for pending {@link Pool#acquire()} Monos, used as a stack ({@link java.util.Deque#offerFirst(Object)},
+ * This implementation is based on {@link java.util.concurrent.ConcurrentLinkedQueue} MPMC queue
+ * for idle resources and a {@link ConcurrentLinkedDeque} for pending {@link Pool#acquire()}
+ * Monos, used as a stack ({@link java.util.Deque#offerFirst(Object)},
  * {@link Deque#pollFirst()}. This results in serving pending borrowers in LIFO order.
  *
  * See {@link SimplePool} for other characteristics of the simple pool.


### PR DESCRIPTION
The need for MPMC queues for pending monos arises from the fact that
cancelling an acquire (with or without a timeout) now introduces
potential new concurrent consumers.