### PR TITLE
fix #49 Introduce reactor-pool specific exceptions

### DIFF
--- a/src/main/java/reactor/pool/AbstractPool.java
+++ b/src/main/java/reactor/pool/AbstractPool.java
@@ -285,8 +285,7 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
         public void run() {
             if (Borrower.this.compareAndSet(false, true)) {
                 pool.cancelAcquire(Borrower.this);
-                actual.onError(new TimeoutException("Acquire has been pending for more than the " +
-                        "configured timeout of " + acquireTimeout.toMillis() + "ms"));
+                actual.onError(new PoolAcquireTimeoutException(acquireTimeout));
             }
         }
 

--- a/src/main/java/reactor/pool/AffinityPool.java
+++ b/src/main/java/reactor/pool/AffinityPool.java
@@ -109,7 +109,7 @@ final class AffinityPool<POOLABLE> extends AbstractPool<POOLABLE> {
     @Override
     void doAcquire(Borrower<POOLABLE> borrower) {
         if (pools == TERMINATED) {
-            borrower.fail(new RuntimeException("Pool has been shut down"));
+            borrower.fail(new PoolShutdownException());
             return;
         }
 
@@ -264,7 +264,7 @@ final class AffinityPool<POOLABLE> extends AbstractPool<POOLABLE> {
                 for (SubPool<POOLABLE> subPool : toClose.values()) {
                     Borrower<POOLABLE> pending;
                     while((pending = subPool.pollPending()) != null) {
-                        pending.fail(new RuntimeException("Pool has been shut down"));
+                        pending.fail(new PoolShutdownException());
                     }
                 }
                 toClose.clear();
@@ -366,7 +366,7 @@ final class AffinityPool<POOLABLE> extends AbstractPool<POOLABLE> {
             for (;;) {
                 int currentPending = AbstractPool.PENDING_COUNT.get(parent);
                 if (maxPending >= 0 && currentPending == maxPending) {
-                    pending.fail(new IllegalStateException("Pending acquire queue has reached its maximum size of " + maxPending));
+                    pending.fail(new PoolAcquirePendingLimitException(maxPending));
                     return;
                 }
                 else if (AbstractPool.PENDING_COUNT.compareAndSet(parent, currentPending, currentPending + 1)) {
@@ -406,7 +406,7 @@ final class AffinityPool<POOLABLE> extends AbstractPool<POOLABLE> {
             for (;;) {
                 int currentPending = AbstractPool.PENDING_COUNT.get(parent);
                 if (maxPending >= 0 && currentPending == maxPending) {
-                    pending.fail(new IllegalStateException("Pending acquire queue has reached its maximum size of " + maxPending));
+                    pending.fail(new PoolAcquirePendingLimitException(maxPending));
                     return;
                 }
                 else if (AbstractPool.PENDING_COUNT.compareAndSet(parent, currentPending, currentPending + 1)) {

--- a/src/main/java/reactor/pool/PoolAcquirePendingLimitException.java
+++ b/src/main/java/reactor/pool/PoolAcquirePendingLimitException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool;
+
+/**
+ * A {@link RuntimeException} that rejects a {@link Pool#acquire()} operation due to too
+ * many similar operations being in a pending state waiting for resources to be released.
+ * The configured maximum pending size for the {@link Pool} can be obtained by calling
+ * {@link #getAcquirePendingLimit()}.
+ *
+ * @author Simon Baslé
+ */
+public class PoolAcquirePendingLimitException extends RuntimeException {
+
+	private final int maxPending;
+
+	public PoolAcquirePendingLimitException(int maxPending) {
+		super("Pending acquire queue has reached its maximum size of " + maxPending);
+		this.maxPending = maxPending;
+	}
+
+	/**
+	 * @return the configured maximum pending size for the {@link Pool}
+	 */
+	public int getAcquirePendingLimit() {
+		return this.maxPending;
+	}
+}

--- a/src/main/java/reactor/pool/PoolAcquireTimeoutException.java
+++ b/src/main/java/reactor/pool/PoolAcquireTimeoutException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool;
+
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A specialized {@link TimeoutException} that denotes that a {@link Pool#acquire(Duration)}
+ * has timed out. Said {@link Duration} can be obtained via {@link #getAcquireTimeout()}.
+ *
+ * @author Simon Baslé
+ */
+public class PoolAcquireTimeoutException extends TimeoutException {
+
+	private final Duration acquireTimeout;
+
+	public PoolAcquireTimeoutException(Duration acquireTimeout) {
+		super("Pool#acquire(Duration) has been pending for more than the configured timeout of " + acquireTimeout.toMillis() + "ms");
+		this.acquireTimeout = acquireTimeout;
+	}
+
+	/**
+	 * @return the configured acquire timeout that was just overshot
+	 */
+	public Duration getAcquireTimeout() {
+		return acquireTimeout;
+	}
+}

--- a/src/main/java/reactor/pool/PoolShutdownException.java
+++ b/src/main/java/reactor/pool/PoolShutdownException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool;
+
+/**
+ * A {@link RuntimeException} that denotes that a {@link Pool} has been
+ * {@link Pool#dispose() disposed}.
+ *
+ * @author Simon Baslé
+ */
+public class PoolShutdownException extends RuntimeException {
+
+	public PoolShutdownException() {
+		super("Pool has been shut down");
+	}
+
+}

--- a/src/main/java/reactor/pool/SimpleFifoPool.java
+++ b/src/main/java/reactor/pool/SimpleFifoPool.java
@@ -49,7 +49,7 @@ final class SimpleFifoPool<POOLABLE> extends SimplePool<POOLABLE> {
         for (;;) {
             int currentPending = PENDING_COUNT.get(this);
             if (maxPending >= 0 && currentPending == maxPending) {
-                pending.fail(new IllegalStateException("Pending acquire queue has reached its maximum size of " + maxPending));
+                pending.fail(new PoolAcquirePendingLimitException(maxPending));
                 return false;
             }
             else if (PENDING_COUNT.compareAndSet(this, currentPending, currentPending + 1)) {
@@ -84,7 +84,7 @@ final class SimpleFifoPool<POOLABLE> extends SimplePool<POOLABLE> {
             Queue<Borrower<POOLABLE>> q = PENDING.getAndSet(this, TERMINATED);
             if (q != TERMINATED) {
                 while(!q.isEmpty()) {
-                    q.poll().fail(new RuntimeException("Pool has been shut down"));
+                    q.poll().fail(new PoolShutdownException());
                 }
 
                 Mono<Void> destroyMonos = Mono.when();

--- a/src/main/java/reactor/pool/SimpleLifoPool.java
+++ b/src/main/java/reactor/pool/SimpleLifoPool.java
@@ -51,7 +51,7 @@ final class SimpleLifoPool<POOLABLE> extends SimplePool<POOLABLE> {
         for (;;) {
             int currentPending = PENDING_COUNT.get(this);
             if (maxPending >= 0 && currentPending == maxPending) {
-                pending.fail(new IllegalStateException("Pending acquire queue has reached its maximum size of " + maxPending));
+                pending.fail(new PoolAcquirePendingLimitException(maxPending));
                 return false;
             }
             else if (PENDING_COUNT.compareAndSet(this, currentPending, currentPending + 1)) {
@@ -87,7 +87,7 @@ final class SimpleLifoPool<POOLABLE> extends SimplePool<POOLABLE> {
             if (q != TERMINATED) {
                 Borrower<POOLABLE> p;
                 while((p = q.pollFirst()) != null) {
-                    p.fail(new RuntimeException("Pool has been shut down"));
+                    p.fail(new PoolShutdownException());
                 }
 
                 Mono<Void> destroyMonos = Mono.when();

--- a/src/main/java/reactor/pool/SimplePool.java
+++ b/src/main/java/reactor/pool/SimplePool.java
@@ -105,7 +105,7 @@ abstract class SimplePool<POOLABLE> extends AbstractPool<POOLABLE> {
     @Override
     void doAcquire(Borrower<POOLABLE> borrower) {
         if (isDisposed()) {
-            borrower.fail(new RuntimeException("Pool has been shut down"));
+            borrower.fail(new PoolShutdownException());
             return;
         }
 

--- a/src/test/java/reactor/pool/CommonPoolTest.java
+++ b/src/test/java/reactor/pool/CommonPoolTest.java
@@ -776,7 +776,7 @@ public class CommonPoolTest {
 			assertThat(errorCount).as("immediate error of extraneous pending").hasValue(1);
 			assertThat(otherTerminationCount).as("no other immediate termination").hasValue(0);
 			assertThat(error.get()).as("extraneous pending error")
-			                       .isInstanceOf(IllegalStateException.class)
+			                       .isInstanceOf(PoolAcquirePendingLimitException.class)
 			                       .hasMessage("Pending acquire queue has reached its maximum size of 1");
 
 			hold.release().block();
@@ -823,7 +823,7 @@ public class CommonPoolTest {
 			assertThat(errorCount).as("immediate error of extraneous pending").hasValue(1);
 			assertThat(otherTerminationCount).as("no other immediate termination").hasValue(0);
 			assertThat(error.get()).as("extraneous pending error")
-			                       .isInstanceOf(IllegalStateException.class)
+			                       .isInstanceOf(PoolAcquirePendingLimitException.class)
 			                       .hasMessage("Pending acquire queue has reached its maximum size of 1");
 
 			hold.release().block();
@@ -1224,7 +1224,8 @@ public class CommonPoolTest {
 		            .thenAwait(Duration.ofMillis(1))
 		            .verifyErrorSatisfies(e -> assertThat(e)
 				            .isInstanceOf(TimeoutException.class)
-				            .hasMessage("Acquire has been pending for more than the configured timeout of 100ms"));
+				            .isExactlyInstanceOf(PoolAcquireTimeoutException.class)
+				            .hasMessage("Pool#acquire(Duration) has been pending for more than the configured timeout of 100ms"));
 	}
 
 	@ParameterizedTest
@@ -1246,7 +1247,8 @@ public class CommonPoolTest {
 		            .thenAwait(Duration.ofMillis(1))
 		            .verifyErrorSatisfies(e -> assertThat(e)
 				            .isInstanceOf(TimeoutException.class)
-				            .hasMessage("Acquire has been pending for more than the configured timeout of 100ms"));
+				            .isExactlyInstanceOf(PoolAcquireTimeoutException.class)
+				            .hasMessage("Pool#acquire(Duration) has been pending for more than the configured timeout of 100ms"));
 
 		assertThat(resource).as("post timeout but before resource available").hasValue(0);
 


### PR DESCRIPTION
 - `PoolAcquireTimeoutException` is still a `TimeoutException`,
 but specialized (and which exposes a getter for the timeout).
 - `PoolAcquirePendingLimitException` replaces a too generic
 `IllegalStateException` and exposes the pending limit in a getter.
 - `PoolShutdownException` replaces the way too generic `RuntimeException`
 previously in place.