### PR TITLE
fix #51 Expose PoolConfig, rework PoolBuilder with factory

### DIFF
--- a/src/main/java/reactor/pool/AbstractPool.java
+++ b/src/main/java/reactor/pool/AbstractPool.java
@@ -19,11 +19,9 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-import java.util.function.BiPredicate;
 import java.util.function.Function;
 
 import org.reactivestreams.Publisher;
@@ -35,7 +33,6 @@ import reactor.core.Disposables;
 import reactor.core.Scannable;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;
-import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.Logger;
 import reactor.util.annotation.Nullable;
@@ -54,14 +51,14 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
     //This helps with testability of some methods that for now mainly log
     final Logger logger;
 
-    final DefaultPoolConfig<POOLABLE> poolConfig;
+    final PoolConfig<POOLABLE> poolConfig;
 
     final PoolMetricsRecorder metricsRecorder;
 
     volatile     int                                     pendingCount;
     static final AtomicIntegerFieldUpdater<AbstractPool> PENDING_COUNT = AtomicIntegerFieldUpdater.newUpdater(AbstractPool.class, "pendingCount");
 
-    AbstractPool(DefaultPoolConfig<POOLABLE> poolConfig, Logger logger) {
+    AbstractPool(PoolConfig<POOLABLE> poolConfig, Logger logger) {
         this.poolConfig = poolConfig;
         this.logger = logger;
         this.metricsRecorder = poolConfig.metricsRecorder;
@@ -356,92 +353,4 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
         }
     }
 
-    /**
-     * A inner representation of a {@link AbstractPool} configuration.
-     *
-     * @author Simon Baslé
-     */
-    static class DefaultPoolConfig<POOLABLE> {
-
-        /**
-         * The asynchronous factory that produces new resources, represented as a {@link Mono}.
-         */
-        final Mono<POOLABLE>                                allocator;
-        //TODO to be removed
-        /**
-         * The minimum number of objects a {@link Pool} should create at initialization.
-         */
-        final int                                           initialSize;
-        /**
-         * {@link AllocationStrategy} defines a strategy / limit for the number of pooled object to allocate.
-         */
-        final AllocationStrategy                            allocationStrategy;
-        /**
-         * The maximum number of pending borrowers to enqueue before failing fast. 0 will immediately fail any acquire
-         * when no idle resource is available and the pool cannot grow. Use a negative number to deactivate.
-         */
-        final int                                           maxPending;
-        /**
-         * When a resource is {@link PooledRef#release() released}, defines a mechanism of resetting any lingering state of
-         * the resource in order for it to become usable again. The {@link #evictionPredicate} is applied AFTER this reset.
-         * <p>
-         * For example, a buffer could have a readerIndex and writerIndex that need to be flipped back to zero.
-         */
-        final Function<POOLABLE, ? extends Publisher<Void>> releaseHandler;
-        /**
-         * Defines a mechanism of resource destruction, cleaning up state and OS resources it could maintain (eg. off-heap
-         * objects, file handles, socket connections, etc...).
-         * <p>
-         * For example, a database connection could need to cleanly sever the connection link by sending a message to the database.
-         */
-        final Function<POOLABLE, ? extends Publisher<Void>> destroyHandler;
-        /**
-         * A {@link BiPredicate} that checks if a resource should be destroyed ({@code true}) or is still in a valid state
-         * for recycling. This is primarily applied when a resource is released, to check whether or not it can immediately
-         * be recycled, but could also be applied during an acquire attempt (detecting eg. idle resources) or by a background
-         * reaping process. Both the resource and some {@link PooledRefMetadata metrics} about the resource's life within the pool are provided.
-         */
-        final BiPredicate<POOLABLE, PooledRefMetadata>      evictionPredicate;
-        /**
-         * The {@link Scheduler} on which the {@link Pool} should publish resources, independently of which thread called
-         * {@link Pool#acquire()} or {@link PooledRef#release()} or on which thread the {@link #allocator} produced new
-         * resources.
-         * <p>
-         * Use {@link Schedulers#immediate()} if determinism is less important than staying on the same threads.
-         */
-        final Scheduler                                     acquisitionScheduler;
-        /**
-         * The {@link PoolMetricsRecorder} to use to collect instrumentation data of the {@link Pool}
-         * implementations.
-         */
-        final PoolMetricsRecorder                           metricsRecorder;
-
-        /**
-         * The order in which pending borrowers are served ({@code false} for FIFO, {@code true} for LIFO).
-         * Defaults to {@code false} (FIFO).
-         */
-        final boolean                                       isLifo;
-
-        DefaultPoolConfig(Mono<POOLABLE> allocator,
-                          int initialSize,
-                          AllocationStrategy allocationStrategy,
-                          int maxPending,
-                          Function<POOLABLE, ? extends Publisher<Void>> releaseHandler,
-                          Function<POOLABLE, ? extends Publisher<Void>> destroyHandler,
-                          BiPredicate<POOLABLE, PooledRefMetadata> evictionPredicate,
-                          Scheduler acquisitionScheduler,
-                          PoolMetricsRecorder metricsRecorder,
-                          boolean isLifo) {
-            this.allocator = allocator;
-            this.initialSize = initialSize;
-            this.allocationStrategy = allocationStrategy;
-            this.maxPending = maxPending;
-            this.releaseHandler = releaseHandler;
-            this.destroyHandler = destroyHandler;
-            this.evictionPredicate = evictionPredicate;
-            this.acquisitionScheduler = acquisitionScheduler;
-            this.metricsRecorder = metricsRecorder;
-            this.isLifo = isLifo;
-        }
-    }
 }

--- a/src/main/java/reactor/pool/DefaultPoolConfig.java
+++ b/src/main/java/reactor/pool/DefaultPoolConfig.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2018-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool;
+
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+
+import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+
+/**
+ * A default {@link PoolConfig} that can be extended to bear more configuration options
+ * with access to a copy constructor for the basic options.
+ *
+ * @author Simon Baslé
+ */
+public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
+
+	protected final Mono<POOLABLE>                                allocator;
+	protected final int                                           initialSize;
+	protected final AllocationStrategy                            allocationStrategy;
+	protected final int                                           maxPending;
+	protected final Function<POOLABLE, ? extends Publisher<Void>> releaseHandler;
+	protected final Function<POOLABLE, ? extends Publisher<Void>> destroyHandler;
+	protected final BiPredicate<POOLABLE, PooledRefMetadata>      evictionPredicate;
+	protected final Scheduler                                     acquisitionScheduler;
+	protected final PoolMetricsRecorder                           metricsRecorder;
+
+	public DefaultPoolConfig(Mono<POOLABLE> allocator,
+			int initialSize,
+			AllocationStrategy allocationStrategy,
+			int maxPending,
+			Function<POOLABLE, ? extends Publisher<Void>> releaseHandler,
+			Function<POOLABLE, ? extends Publisher<Void>> destroyHandler,
+			BiPredicate<POOLABLE, PooledRefMetadata> evictionPredicate,
+			Scheduler acquisitionScheduler,
+			PoolMetricsRecorder metricsRecorder) {
+		this.allocator = allocator;
+		this.initialSize = initialSize;
+		this.allocationStrategy = allocationStrategy;
+		this.maxPending = maxPending;
+		this.releaseHandler = releaseHandler;
+		this.destroyHandler = destroyHandler;
+		this.evictionPredicate = evictionPredicate;
+		this.acquisitionScheduler = acquisitionScheduler;
+		this.metricsRecorder = metricsRecorder;
+	}
+
+	/**
+	 * Copy constructor for the benefit of specializations of {@link PoolConfig}.
+	 *
+	 * @param toCopy the original {@link PoolConfig} to copy (only standard {@link PoolConfig}
+	 * options are copied).
+	 */
+	protected DefaultPoolConfig(PoolConfig<POOLABLE> toCopy) {
+		if (toCopy instanceof DefaultPoolConfig) {
+			DefaultPoolConfig<POOLABLE> toCopyDpc = (DefaultPoolConfig<POOLABLE>) toCopy;
+			this.allocator = toCopyDpc.allocator;
+			this.initialSize = toCopyDpc.initialSize;
+			this.allocationStrategy = toCopyDpc.allocationStrategy;
+			this.maxPending = toCopyDpc.maxPending;
+			this.releaseHandler = toCopyDpc.releaseHandler;
+			this.destroyHandler = toCopyDpc.destroyHandler;
+			this.evictionPredicate = toCopyDpc.evictionPredicate;
+			this.acquisitionScheduler = toCopyDpc.acquisitionScheduler;
+			this.metricsRecorder = toCopyDpc.metricsRecorder;
+		}
+		else {
+			this.allocator = toCopy.allocator();
+			this.initialSize = toCopy.initialSize();
+			this.allocationStrategy = toCopy.allocationStrategy();
+			this.maxPending = toCopy.maxPending();
+			this.releaseHandler = toCopy.releaseHandler();
+			this.destroyHandler = toCopy.destroyHandler();
+			this.evictionPredicate = toCopy.evictionPredicate();
+			this.acquisitionScheduler = toCopy.acquisitionScheduler();
+			this.metricsRecorder = toCopy.metricsRecorder();
+		}
+	}
+
+	@Override
+	public Mono<POOLABLE> allocator() {
+		return this.allocator;
+	}
+
+	@Override
+	public int initialSize() {
+		return this.initialSize;
+	}
+
+	@Override
+	public AllocationStrategy allocationStrategy() {
+		return this.allocationStrategy;
+	}
+
+	@Override
+	public int maxPending() {
+		return this.maxPending;
+	}
+
+	@Override
+	public Function<POOLABLE, ? extends Publisher<Void>> releaseHandler() {
+		return this.releaseHandler;
+	}
+
+	@Override
+	public Function<POOLABLE, ? extends Publisher<Void>> destroyHandler() {
+		return this.destroyHandler;
+	}
+
+	@Override
+	public BiPredicate<POOLABLE, PooledRefMetadata> evictionPredicate() {
+		return this.evictionPredicate;
+	}
+
+	@Override
+	public Scheduler acquisitionScheduler() {
+		return this.acquisitionScheduler;
+	}
+
+	@Override
+	public PoolMetricsRecorder metricsRecorder() {
+		return this.metricsRecorder;
+	}
+}

--- a/src/main/java/reactor/pool/PoolBuilder.java
+++ b/src/main/java/reactor/pool/PoolBuilder.java
@@ -289,7 +289,7 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
      *
      * @return a builder of {@link Pool} with LIFO pending acquire ordering.
      */
-    public Pool<T> lifo() {
+    public InstrumentedPool<T> lifo() {
         return build(SimpleLifoPool::new);
     }
 
@@ -300,7 +300,7 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
      *
      * @return a builder of {@link Pool} with FIFO pending acquire ordering.
      */
-    public Pool<T> fifo() {
+    public InstrumentedPool<T> fifo() {
         return build(SimpleFifoPool::new);
     }
 

--- a/src/main/java/reactor/pool/PoolBuilder.java
+++ b/src/main/java/reactor/pool/PoolBuilder.java
@@ -30,12 +30,15 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 /**
- * A builder for {@link Pool}.
+ * A builder for {@link Pool} implementations, which tuning methods map
+ * to a {@link PoolConfig} subclass, {@code CONF}.
+ *
+ * @param <T> the type of elements in the produced {@link Pool}
+ * @param <CONF> the {@link PoolConfig} flavor this builder will provide to the create {@link Pool}
  *
  * @author Simon Baslé
  */
-@SuppressWarnings("WeakerAccess")
-public class PoolBuilder<T> {
+public class PoolBuilder<T, CONF extends PoolConfig<T>> {
 
     /**
      * Start building a {@link Pool} by describing how new objects are to be asynchronously allocated.
@@ -51,13 +54,13 @@ public class PoolBuilder<T> {
      * @param <T> the type of resource created and recycled by the {@link Pool}
      * @return a builder of {@link Pool}
      */
-    public static <T> PoolBuilder<T> from(Publisher<? extends T> allocator) {
+    public static <T> PoolBuilder<T, PoolConfig<T>> from(Publisher<? extends T> allocator) {
         Mono<T> source = Mono.from(allocator);
-        return new PoolBuilder<>(source);
+        return new PoolBuilder<>(source, Function.identity());
     }
 
     final Mono<T> allocator;
-    boolean                                isLifo               = false;
+    final Function<PoolConfig<T>, CONF>    configModifier;
     int                                    initialSize          = 0;
     int                                    maxPending           = -1;
     AllocationStrategy                     allocationStrategy   = null;
@@ -67,8 +70,23 @@ public class PoolBuilder<T> {
     Scheduler                              acquisitionScheduler = Schedulers.immediate();
     PoolMetricsRecorder                    metricsRecorder      = NoOpPoolMetricsRecorder.INSTANCE;
 
-    PoolBuilder(Mono<T> allocator) {
+    PoolBuilder(Mono<T> allocator, Function<PoolConfig<T>, CONF> configModifier) {
         this.allocator = allocator;
+        this.configModifier = configModifier;
+    }
+
+    PoolBuilder(PoolBuilder<T, ?> source, Function<PoolConfig<T>, CONF> configModifier) {
+        this.configModifier = configModifier;
+
+        this.allocator = source.allocator;
+        this.initialSize = source.initialSize;
+        this.maxPending = source.maxPending;
+        this.allocationStrategy = source.allocationStrategy;
+        this.releaseHandler = source.releaseHandler;
+        this.destroyHandler = source.destroyHandler;
+        this.evictionPredicate = source.evictionPredicate;
+        this.acquisitionScheduler = source.acquisitionScheduler;
+        this.metricsRecorder = source.metricsRecorder;
     }
 
     /**
@@ -81,7 +99,7 @@ public class PoolBuilder<T> {
      * @param acquisitionScheduler the {@link Scheduler} on which to deliver acquired resources
      * @return this {@link Pool} builder
      */
-    public PoolBuilder<T> acquisitionScheduler(Scheduler acquisitionScheduler) {
+    public PoolBuilder<T, CONF> acquisitionScheduler(Scheduler acquisitionScheduler) {
         this.acquisitionScheduler = Objects.requireNonNull(acquisitionScheduler, "acquisitionScheduler");
         return this;
     }
@@ -98,7 +116,7 @@ public class PoolBuilder<T> {
      * @see #sizeMax(int)
      * @see #sizeUnbounded()
      */
-    public PoolBuilder<T> allocationStrategy(AllocationStrategy allocationStrategy) {
+    public PoolBuilder<T, CONF> allocationStrategy(AllocationStrategy allocationStrategy) {
         this.allocationStrategy = Objects.requireNonNull(allocationStrategy, "allocationStrategy");
         return this;
     }
@@ -114,7 +132,7 @@ public class PoolBuilder<T> {
      * @param destroyHandler the {@link Function} supplying the state-resetting {@link Publisher}
      * @return this {@link Pool} builder
      */
-    public PoolBuilder<T> destroyHandler(Function<T, ? extends Publisher<Void>> destroyHandler) {
+    public PoolBuilder<T, CONF> destroyHandler(Function<T, ? extends Publisher<Void>> destroyHandler) {
         this.destroyHandler = Objects.requireNonNull(destroyHandler, "destroyHandler");
         return this;
     }
@@ -129,7 +147,7 @@ public class PoolBuilder<T> {
      * @return this {@link Pool} builder
      * @see #evictionPredicate(BiPredicate)
      */
-    public PoolBuilder<T> evictionIdle(Duration maxIdleTime) {
+    public PoolBuilder<T, CONF> evictionIdle(Duration maxIdleTime) {
         return evictionPredicate(idlePredicate(maxIdleTime));
     }
 
@@ -148,7 +166,7 @@ public class PoolBuilder<T> {
      * @return this {@link Pool} builder
      * @see #evictionIdle(Duration)
      */
-    public PoolBuilder<T> evictionPredicate(BiPredicate<T, PooledRefMetadata> evictionPredicate) {
+    public PoolBuilder<T, CONF> evictionPredicate(BiPredicate<T, PooledRefMetadata> evictionPredicate) {
         this.evictionPredicate = Objects.requireNonNull(evictionPredicate, "evictionPredicate");
         return this;
     }
@@ -162,24 +180,11 @@ public class PoolBuilder<T> {
      * @param n the initial size of the {@link Pool}.
      * @return this {@link Pool} builder
      */
-    public PoolBuilder<T> initialSize(int n) {
+    public PoolBuilder<T, CONF> initialSize(int n) {
         if (n < 0) {
             throw new IllegalArgumentException("initialSize must be >= 0");
         }
         this.initialSize = n;
-        return this;
-    }
-
-    /**
-     * Change the order in which pending {@link Pool#acquire()} {@link Mono Monos} are served
-     * whenever a resource becomes available. The default is FIFO, but passing true to this
-     * method changes it to LIFO.
-     *
-     * @param isLastInFirstOut should the pending order be LIFO ({@code true}) or FIFO ({@code false})?
-     * @return a builder of {@link Pool} with the requested pending acquire ordering.
-     */
-    public PoolBuilder<T> lifo(boolean isLastInFirstOut) {
-        this.isLifo = isLastInFirstOut;
         return this;
     }
 
@@ -195,7 +200,7 @@ public class PoolBuilder<T> {
      * @param maxPending the maximum number of registered acquire monos to keep in a pending queue
      * @return a builder of {@link Pool} with a maximum pending queue size.
      */
-    public PoolBuilder<T> maxPendingAcquire(int maxPending) {
+    public PoolBuilder<T, CONF> maxPendingAcquire(int maxPending) {
         this.maxPending = maxPending;
         return this;
     }
@@ -209,7 +214,7 @@ public class PoolBuilder<T> {
      *
      * @return a builder of {@link Pool} with no maximum pending queue size.
      */
-    public PoolBuilder<T> maxPendingAcquireUnbounded() {
+    public PoolBuilder<T, CONF> maxPendingAcquireUnbounded() {
         this.maxPending = -1;
         return this;
     }
@@ -220,7 +225,7 @@ public class PoolBuilder<T> {
      * @param recorder the {@link PoolMetricsRecorder}
      * @return this {@link Pool} builder
      */
-    public PoolBuilder<T> metricsRecorder(PoolMetricsRecorder recorder) {
+    public PoolBuilder<T, CONF> metricsRecorder(PoolMetricsRecorder recorder) {
         this.metricsRecorder = Objects.requireNonNull(recorder, "recorder");
         return this;
     }
@@ -235,59 +240,97 @@ public class PoolBuilder<T> {
      * @param releaseHandler the {@link Function} supplying the state-resetting {@link Publisher}
      * @return this {@link Pool} builder
      */
-    public PoolBuilder<T> releaseHandler(Function<T, ? extends Publisher<Void>> releaseHandler) {
+    public PoolBuilder<T, CONF> releaseHandler(Function<T, ? extends Publisher<Void>> releaseHandler) {
         this.releaseHandler = Objects.requireNonNull(releaseHandler, "releaseHandler");
         return this;
     }
 
     /**
-	 * Let the {@link Pool} allocate at most {@code max} resources, rejecting further allocations until
-	 * some resources have been {@link PooledRef#release() released}.
-	 *
-	 * @param max the maximum number of live resources to keep in the pool
+     * Let the {@link Pool} allocate at most {@code max} resources, rejecting further allocations until
+     * some resources have been {@link PooledRef#release() released}.
+     *
+     * @param max the maximum number of live resources to keep in the pool
      * @return this {@link Pool} builder
-	 */
-	public PoolBuilder<T> sizeMax(int max) {
-		return allocationStrategy(new AllocationStrategies.SizeBasedAllocationStrategy(max));
-	}
-
-	/**
-	 * Let the {@link Pool} allocate new resources when no idle resource is available, without limit.
-	 * <p>
-	 * Note this is the default, if no previous call to {@link #allocationStrategy(AllocationStrategy)}
-	 * or {@link #sizeMax(int)} has been made on this {@link PoolBuilder}.
-	 *
-     * @return this {@link Pool} builder
-	 */
-	public PoolBuilder<T> sizeUnbounded() {
-		return allocationStrategy(new AllocationStrategies.UnboundedAllocationStrategy());
-	}
+     */
+    public PoolBuilder<T, CONF> sizeMax(int max) {
+        return allocationStrategy(new AllocationStrategies.SizeBasedAllocationStrategy(max));
+    }
 
     /**
-     * Build the {@link Pool}.
+     * Let the {@link Pool} allocate new resources when no idle resource is available, without limit.
+     * <p>
+     * Note this is the default, if no previous call to {@link #allocationStrategy(AllocationStrategy)}
+     * or {@link #sizeMax(int)} has been made on this {@link PoolBuilder}.
      *
+     * @return this {@link Pool} builder
+     */
+    public PoolBuilder<T, CONF> sizeUnbounded() {
+        return allocationStrategy(new AllocationStrategies.UnboundedAllocationStrategy());
+    }
+
+    /**
+     * Add implementation-specific configuration, changing the type of {@link PoolConfig}
+     * passed to the {@link Pool} factory in {@link #build(Function)}.
+     *
+     * @param configModifier {@link Function} to transform the type of {@link PoolConfig}
+     * create by this builder for the benefit of the pool factory, allowing for custom
+     * implementations with custom configurations
+     * @param <CONF2> new type for the configuration
+     * @return a new PoolBuilder that now produces a different type of {@link PoolConfig}
+     */
+    public <CONF2 extends PoolConfig<T>> PoolBuilder<T, CONF2> extraConfiguration(Function<? super CONF, CONF2> configModifier) {
+        return new PoolBuilder<>(this, this.configModifier.andThen(configModifier));
+    }
+
+    /**
+     * Build a LIFO flavor of {@link Pool}, that is to say a flavor where the last
+     * {@link Pool#acquire()} {@link Mono Mono} that was pending is served first
+     * whenever a resource becomes available.
+     *
+     * @return a builder of {@link Pool} with LIFO pending acquire ordering.
+     */
+    public Pool<T> lifo() {
+        return build(SimpleLifoPool::new);
+    }
+
+    /**
+     * Build the default flavor of {@link Pool}, which has FIFO semantics on pending
+     * {@link Pool#acquire()} {@link Mono Mono}, serving the oldest pending acquire first
+     * whenever a resource becomes available.
+     *
+     * @return a builder of {@link Pool} with FIFO pending acquire ordering.
+     */
+    public Pool<T> fifo() {
+        return build(SimpleFifoPool::new);
+    }
+
+    /**
+     * Build a custom flavor of {@link Pool}, given a Pool factory {@link Function} that
+     * is provided with a {@link PoolConfig} copy of this builder's configuration.
+     *
+     * @param poolFactory the factory of pool implementation
      * @return the {@link Pool}
      */
-    public Pool<T> build() {
-        AbstractPool.DefaultPoolConfig<T> config = buildConfig();
-        if (isLifo) {
-            return new SimpleLifoPool<>(config);
-        }
-        return new SimpleFifoPool<>(config);
+    public <POOL extends Pool<T>> POOL build(Function<? super CONF, POOL> poolFactory) {
+        CONF config = buildConfig();
+        return poolFactory.apply(config);
     }
 
     //kept package-private for the benefit of tests
-    AbstractPool.DefaultPoolConfig<T> buildConfig() {
-        return new AbstractPool.DefaultPoolConfig<>(allocator,
+    CONF buildConfig() {
+        PoolConfig<T> baseConfig = new PoolConfig<>(allocator,
                 initialSize,
-                allocationStrategy == null ? new AllocationStrategies.UnboundedAllocationStrategy() : allocationStrategy,
+                allocationStrategy == null ?
+                        new AllocationStrategies.UnboundedAllocationStrategy() :
+                        allocationStrategy,
                 maxPending,
                 releaseHandler,
                 destroyHandler,
                 evictionPredicate,
                 acquisitionScheduler,
-                metricsRecorder,
-                isLifo);
+                metricsRecorder);
+
+        return this.configModifier.apply(baseConfig);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/reactor/pool/PoolBuilder.java
+++ b/src/main/java/reactor/pool/PoolBuilder.java
@@ -34,7 +34,7 @@ import reactor.core.scheduler.Schedulers;
  * to a {@link PoolConfig} subclass, {@code CONF}.
  *
  * @param <T> the type of elements in the produced {@link Pool}
- * @param <CONF> the {@link PoolConfig} flavor this builder will provide to the create {@link Pool}
+ * @param <CONF> the {@link PoolConfig} flavor this builder will provide to the created {@link Pool}
  *
  * @author Simon Baslé
  */

--- a/src/main/java/reactor/pool/PoolBuilder.java
+++ b/src/main/java/reactor/pool/PoolBuilder.java
@@ -59,7 +59,7 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
         return new PoolBuilder<>(source, Function.identity());
     }
 
-    final Mono<T> allocator;
+    final Mono<T>                          allocator;
     final Function<PoolConfig<T>, CONF>    configModifier;
     int                                    initialSize          = 0;
     int                                    maxPending           = -1;
@@ -318,7 +318,7 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
 
     //kept package-private for the benefit of tests
     CONF buildConfig() {
-        PoolConfig<T> baseConfig = new PoolConfig<>(allocator,
+        PoolConfig<T> baseConfig = new DefaultPoolConfig<>(allocator,
                 initialSize,
                 allocationStrategy == null ?
                         new AllocationStrategies.UnboundedAllocationStrategy() :

--- a/src/main/java/reactor/pool/PoolConfig.java
+++ b/src/main/java/reactor/pool/PoolConfig.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2018-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool;
+
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+
+import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * A representation of the common configuration options of a {@link Pool}.
+ *
+ * @author Simon Baslé
+ */
+public class PoolConfig<POOLABLE> {
+
+    /**
+     * The asynchronous factory that produces new resources, represented as a {@link Mono}.
+     */
+    public final Mono<POOLABLE>                                allocator;
+
+    /**
+     * The minimum number of objects a {@link Pool} should create at initialization.
+     */
+    public final int                                           initialSize;
+
+    /**
+     * {@link AllocationStrategy} defines a strategy / limit for the number of pooled object to allocate.
+     */
+    public final AllocationStrategy                            allocationStrategy;
+
+    /**
+     * The maximum number of pending borrowers to enqueue before failing fast. 0 will immediately fail any acquire
+     * when no idle resource is available and the pool cannot grow. Use a negative number to deactivate.
+     */
+    public final int                                           maxPending;
+
+    /**
+     * When a resource is {@link PooledRef#release() released}, defines a mechanism of resetting any lingering state of
+     * the resource in order for it to become usable again. The {@link #evictionPredicate} is applied AFTER this reset.
+     * <p>
+     * For example, a buffer could have a readerIndex and writerIndex that need to be flipped back to zero.
+     */
+    public final Function<POOLABLE, ? extends Publisher<Void>> releaseHandler;
+
+    /**
+     * Defines a mechanism of resource destruction, cleaning up state and OS resources it could maintain (eg. off-heap
+     * objects, file handles, socket connections, etc...).
+     * <p>
+     * For example, a database connection could need to cleanly sever the connection link by sending a message to the database.
+     */
+    public final Function<POOLABLE, ? extends Publisher<Void>> destroyHandler;
+
+    /**
+     * A {@link BiPredicate} that checks if a resource should be destroyed ({@code true}) or is still in a valid state
+     * for recycling. This is primarily applied when a resource is released, to check whether or not it can immediately
+     * be recycled, but could also be applied during an acquire attempt (detecting eg. idle resources) or by a background
+     * reaping process. Both the resource and some {@link PooledRefMetadata metrics} about the resource's life within the pool are provided.
+     */
+    public final BiPredicate<POOLABLE, PooledRefMetadata>      evictionPredicate;
+
+    /**
+     * The {@link Scheduler} on which the {@link Pool} should publish resources, independently of which thread called
+     * {@link Pool#acquire()} or {@link PooledRef#release()} or on which thread the {@link #allocator} produced new
+     * resources.
+     * <p>
+     * Use {@link Schedulers#immediate()} if determinism is less important than staying on the same threads.
+     */
+    public final Scheduler                                     acquisitionScheduler;
+
+    /**
+     * The {@link PoolMetricsRecorder} to use to collect instrumentation data of the {@link Pool}
+     * implementations.
+     */
+    public final PoolMetricsRecorder                           metricsRecorder;
+
+    public PoolConfig(Mono<POOLABLE> allocator,
+                      int initialSize,
+                      AllocationStrategy allocationStrategy,
+                      int maxPending,
+                      Function<POOLABLE, ? extends Publisher<Void>> releaseHandler,
+                      Function<POOLABLE, ? extends Publisher<Void>> destroyHandler,
+                      BiPredicate<POOLABLE, PooledRefMetadata> evictionPredicate,
+                      Scheduler acquisitionScheduler,
+                      PoolMetricsRecorder metricsRecorder) {
+        this.allocator = allocator;
+        this.initialSize = initialSize;
+        this.allocationStrategy = allocationStrategy;
+        this.maxPending = maxPending;
+        this.releaseHandler = releaseHandler;
+        this.destroyHandler = destroyHandler;
+        this.evictionPredicate = evictionPredicate;
+        this.acquisitionScheduler = acquisitionScheduler;
+        this.metricsRecorder = metricsRecorder;
+    }
+
+    PoolConfig(PoolConfig<POOLABLE> toCopy) {
+        this.allocator = toCopy.allocator;
+        this.initialSize = toCopy.initialSize;
+        this.allocationStrategy = toCopy.allocationStrategy;
+        this.maxPending = toCopy.maxPending;
+        this.releaseHandler = toCopy.releaseHandler;
+        this.destroyHandler = toCopy.destroyHandler;
+        this.evictionPredicate = toCopy.evictionPredicate;
+        this.acquisitionScheduler = toCopy.acquisitionScheduler;
+        this.metricsRecorder = toCopy.metricsRecorder;
+    }
+}

--- a/src/main/java/reactor/pool/PoolConfig.java
+++ b/src/main/java/reactor/pool/PoolConfig.java
@@ -27,100 +27,73 @@ import reactor.core.scheduler.Schedulers;
 
 /**
  * A representation of the common configuration options of a {@link Pool}.
+ * For a default implementation that is open for extension, see {@link DefaultPoolConfig}.
  *
  * @author Simon Baslé
  */
-public class PoolConfig<POOLABLE> {
+public interface PoolConfig<POOLABLE> {
 
-    /**
-     * The asynchronous factory that produces new resources, represented as a {@link Mono}.
-     */
-    public final Mono<POOLABLE>                                allocator;
+	/**
+	 * The asynchronous factory that produces new resources, represented as a {@link Mono}.
+	 */
+	Mono<POOLABLE> allocator();
 
-    /**
-     * The minimum number of objects a {@link Pool} should create at initialization.
-     */
-    public final int                                           initialSize;
+	/**
+	 * The minimum number of objects a {@link Pool} should create at initialization.
+	 */
+	int initialSize();
 
-    /**
-     * {@link AllocationStrategy} defines a strategy / limit for the number of pooled object to allocate.
-     */
-    public final AllocationStrategy                            allocationStrategy;
+	/**
+	 * {@link AllocationStrategy} defines a strategy / limit for the number of pooled object to allocate.
+	 */
+	AllocationStrategy allocationStrategy();
 
-    /**
-     * The maximum number of pending borrowers to enqueue before failing fast. 0 will immediately fail any acquire
-     * when no idle resource is available and the pool cannot grow. Use a negative number to deactivate.
-     */
-    public final int                                           maxPending;
+	/**
+	 * The maximum number of pending borrowers to enqueue before failing fast. 0 will immediately fail any acquire
+	 * when no idle resource is available and the pool cannot grow. Use a negative number to deactivate.
+	 */
+	int maxPending();
 
-    /**
-     * When a resource is {@link PooledRef#release() released}, defines a mechanism of resetting any lingering state of
-     * the resource in order for it to become usable again. The {@link #evictionPredicate} is applied AFTER this reset.
-     * <p>
-     * For example, a buffer could have a readerIndex and writerIndex that need to be flipped back to zero.
-     */
-    public final Function<POOLABLE, ? extends Publisher<Void>> releaseHandler;
+	/**
+	 * When a resource is {@link PooledRef#release() released}, defines a mechanism of resetting any lingering state of
+	 * the resource in order for it to become usable again. The {@link #evictionPredicate} is applied AFTER this reset.
+	 * <p>
+	 * For example, a buffer could have a readerIndex and writerIndex that need to be flipped back to zero.
+	 */
+	Function<POOLABLE, ? extends Publisher<Void>> releaseHandler();
 
-    /**
-     * Defines a mechanism of resource destruction, cleaning up state and OS resources it could maintain (eg. off-heap
-     * objects, file handles, socket connections, etc...).
-     * <p>
-     * For example, a database connection could need to cleanly sever the connection link by sending a message to the database.
-     */
-    public final Function<POOLABLE, ? extends Publisher<Void>> destroyHandler;
+	/**
+	 * Defines a mechanism of resource destruction, cleaning up state and OS resources it could maintain (eg. off-heap
+	 * objects, file handles, socket connections, etc...).
+	 * <p>
+	 * For example, a database connection could need to cleanly sever the connection link by sending a message to the database.
+	 */
+	Function<POOLABLE, ? extends Publisher<Void>> destroyHandler();
 
-    /**
-     * A {@link BiPredicate} that checks if a resource should be destroyed ({@code true}) or is still in a valid state
-     * for recycling. This is primarily applied when a resource is released, to check whether or not it can immediately
-     * be recycled, but could also be applied during an acquire attempt (detecting eg. idle resources) or by a background
-     * reaping process. Both the resource and some {@link PooledRefMetadata metrics} about the resource's life within the pool are provided.
-     */
-    public final BiPredicate<POOLABLE, PooledRefMetadata>      evictionPredicate;
+	/**
+	 * A {@link BiPredicate} that checks if a resource should be destroyed ({@code true}) or is still in a valid state
+	 * for recycling. This is primarily applied when a resource is released, to check whether or not it can immediately
+	 * be recycled, but could also be applied during an acquire attempt (detecting eg. idle resources) or by a background
+	 * reaping process. Both the resource and some {@link PooledRefMetadata metrics} about the resource's life within the pool are provided.
+	 */
+	BiPredicate<POOLABLE, PooledRefMetadata> evictionPredicate();
 
-    /**
-     * The {@link Scheduler} on which the {@link Pool} should publish resources, independently of which thread called
-     * {@link Pool#acquire()} or {@link PooledRef#release()} or on which thread the {@link #allocator} produced new
-     * resources.
-     * <p>
-     * Use {@link Schedulers#immediate()} if determinism is less important than staying on the same threads.
-     */
-    public final Scheduler                                     acquisitionScheduler;
+	/**
+	 * When set, {@link Pool} implementation MAY decide to use the {@link Scheduler}
+	 * to publish resources in a more deterministic way: the publishing thread would then
+	 * always be the same, independently of which thread called {@link Pool#acquire()} or
+	 * {@link PooledRef#release()} or on which thread the {@link #allocator} produced new
+	 * resources. Note that not all pool implementations are guaranteed to enforce this,
+	 * as they might have their own thread publishing semantics.
+	 * <p>
+	 * Defaults to {@link Schedulers#immediate()}, which inhibits this behavior.
+	 */
+	Scheduler acquisitionScheduler();
 
-    /**
-     * The {@link PoolMetricsRecorder} to use to collect instrumentation data of the {@link Pool}
-     * implementations.
-     */
-    public final PoolMetricsRecorder                           metricsRecorder;
+	/**
+	 * The {@link PoolMetricsRecorder} to use to collect instrumentation data of the {@link Pool}
+	 * implementations.
+	 */
+	PoolMetricsRecorder metricsRecorder();
 
-    public PoolConfig(Mono<POOLABLE> allocator,
-                      int initialSize,
-                      AllocationStrategy allocationStrategy,
-                      int maxPending,
-                      Function<POOLABLE, ? extends Publisher<Void>> releaseHandler,
-                      Function<POOLABLE, ? extends Publisher<Void>> destroyHandler,
-                      BiPredicate<POOLABLE, PooledRefMetadata> evictionPredicate,
-                      Scheduler acquisitionScheduler,
-                      PoolMetricsRecorder metricsRecorder) {
-        this.allocator = allocator;
-        this.initialSize = initialSize;
-        this.allocationStrategy = allocationStrategy;
-        this.maxPending = maxPending;
-        this.releaseHandler = releaseHandler;
-        this.destroyHandler = destroyHandler;
-        this.evictionPredicate = evictionPredicate;
-        this.acquisitionScheduler = acquisitionScheduler;
-        this.metricsRecorder = metricsRecorder;
-    }
-
-    PoolConfig(PoolConfig<POOLABLE> toCopy) {
-        this.allocator = toCopy.allocator;
-        this.initialSize = toCopy.initialSize;
-        this.allocationStrategy = toCopy.allocationStrategy;
-        this.maxPending = toCopy.maxPending;
-        this.releaseHandler = toCopy.releaseHandler;
-        this.destroyHandler = toCopy.destroyHandler;
-        this.evictionPredicate = toCopy.evictionPredicate;
-        this.acquisitionScheduler = toCopy.acquisitionScheduler;
-        this.metricsRecorder = toCopy.metricsRecorder;
-    }
 }

--- a/src/main/java/reactor/pool/SimpleFifoPool.java
+++ b/src/main/java/reactor/pool/SimpleFifoPool.java
@@ -38,7 +38,7 @@ final class SimpleFifoPool<POOLABLE> extends SimplePool<POOLABLE> {
     private static final AtomicReferenceFieldUpdater<SimpleFifoPool, Queue> PENDING = AtomicReferenceFieldUpdater.newUpdater(
             SimpleFifoPool.class, Queue.class, "pending");
 
-    public SimpleFifoPool(DefaultPoolConfig<POOLABLE> poolConfig) {
+    public SimpleFifoPool(PoolConfig<POOLABLE> poolConfig) {
         super(poolConfig);
         this.pending = new ConcurrentLinkedQueue<>(); //unbounded MPMC
     }

--- a/src/main/java/reactor/pool/SimpleFifoPool.java
+++ b/src/main/java/reactor/pool/SimpleFifoPool.java
@@ -45,7 +45,7 @@ final class SimpleFifoPool<POOLABLE> extends SimplePool<POOLABLE> {
 
     @Override
     boolean pendingOffer(Borrower<POOLABLE> pending) {
-        int maxPending = poolConfig.maxPending;
+        int maxPending = poolConfig.maxPending();
         for (;;) {
             int currentPending = PENDING_COUNT.get(this);
             if (maxPending >= 0 && currentPending == maxPending) {

--- a/src/main/java/reactor/pool/SimpleLifoPool.java
+++ b/src/main/java/reactor/pool/SimpleLifoPool.java
@@ -40,7 +40,7 @@ final class SimpleLifoPool<POOLABLE> extends SimplePool<POOLABLE> {
     private static final AtomicReferenceFieldUpdater<SimpleLifoPool, ConcurrentLinkedDeque> PENDING = AtomicReferenceFieldUpdater.newUpdater(
             SimpleLifoPool.class, ConcurrentLinkedDeque.class, "pending");
 
-    public SimpleLifoPool(DefaultPoolConfig<POOLABLE> poolConfig) {
+    public SimpleLifoPool(PoolConfig<POOLABLE> poolConfig) {
         super(poolConfig);
         this.pending = new ConcurrentLinkedDeque<>(); //unbounded
     }

--- a/src/main/java/reactor/pool/SimpleLifoPool.java
+++ b/src/main/java/reactor/pool/SimpleLifoPool.java
@@ -47,7 +47,7 @@ final class SimpleLifoPool<POOLABLE> extends SimplePool<POOLABLE> {
 
     @Override
     boolean pendingOffer(Borrower<POOLABLE> pending) {
-        int maxPending = poolConfig.maxPending;
+        int maxPending = poolConfig.maxPending();
         for (;;) {
             int currentPending = PENDING_COUNT.get(this);
             if (maxPending >= 0 && currentPending == maxPending) {

--- a/src/main/java/reactor/pool/SimplePool.java
+++ b/src/main/java/reactor/pool/SimplePool.java
@@ -61,7 +61,7 @@ abstract class SimplePool<POOLABLE> extends AbstractPool<POOLABLE> {
             SimplePool.class, "wip");
 
 
-    SimplePool(DefaultPoolConfig<POOLABLE> poolConfig) {
+    SimplePool(PoolConfig<POOLABLE> poolConfig) {
         super(poolConfig, Loggers.getLogger(SimplePool.class));
         this.elements = Queues.<QueuePooledRef<POOLABLE>>unboundedMultiproducer().get();
 

--- a/src/test/java/reactor/pool/CommonPoolTest.java
+++ b/src/test/java/reactor/pool/CommonPoolTest.java
@@ -66,12 +66,11 @@ import static org.awaitility.Awaitility.await;
  */
 public class CommonPoolTest {
 
-	static final <T> Function<PoolBuilder<T>, AbstractPool<T>> simplePoolFifo() {
-		return new Function<PoolBuilder<T>, AbstractPool<T>>() {
+	static final <T> Function<PoolBuilder<T, ?>, AbstractPool<T>> simplePoolFifo() {
+		return new Function<PoolBuilder<T, ?>, AbstractPool<T>>() {
 			@Override
-			public AbstractPool<T> apply(PoolBuilder<T> builder) {
-				return (AbstractPool<T>) builder.lifo(false)
-				                                .build();
+			public AbstractPool<T> apply(PoolBuilder<T, ?> builder) {
+				return (AbstractPool<T>) builder.fifo();
 			}
 
 			@Override
@@ -81,12 +80,11 @@ public class CommonPoolTest {
 		};
 	}
 
-	static final <T> Function<PoolBuilder<T>, AbstractPool<T>> simplePoolLifo() {
-		return new Function<PoolBuilder<T>, AbstractPool<T>>() {
+	static final <T> Function<PoolBuilder<T, ?>, AbstractPool<T>> simplePoolLifo() {
+		return new Function<PoolBuilder<T, ?>, AbstractPool<T>>() {
 			@Override
-			public AbstractPool<T> apply(PoolBuilder<T> builder) {
-				return (AbstractPool<T>) builder.lifo(true)
-				                                .build();
+			public AbstractPool<T> apply(PoolBuilder<T, ?> builder) {
+				return (AbstractPool<T>) builder.lifo();
 			}
 
 			@Override
@@ -96,24 +94,24 @@ public class CommonPoolTest {
 		};
 	}
 
-	static <T> List<Function<PoolBuilder<T>, AbstractPool<T>>> allPools() {
+	static <T> List<Function<PoolBuilder<T, ?>, AbstractPool<T>>> allPools() {
 		return Arrays.asList(simplePoolFifo(), simplePoolLifo());
 	}
 
-	static <T> List<Function<PoolBuilder<T>, AbstractPool<T>>> fifoPools() {
+	static <T> List<Function<PoolBuilder<T, ?>, AbstractPool<T>>> fifoPools() {
 		return Arrays.asList(simplePoolFifo());
 	}
 
-	static <T> List<Function<PoolBuilder<T>, AbstractPool<T>>> lifoPools() {
+	static <T> List<Function<PoolBuilder<T, ?>, AbstractPool<T>>> lifoPools() {
 		return Arrays.asList(simplePoolLifo());
 	}
 
 	@ParameterizedTest
 	@MethodSource("fifoPools")
-	void smokeTestFifo(Function<PoolBuilder<PoolableTest>, Pool<PoolableTest>> configAdjuster) throws InterruptedException {
+	void smokeTestFifo(Function<PoolBuilder<PoolableTest, ?>, Pool<PoolableTest>> configAdjuster) throws InterruptedException {
 		AtomicInteger newCount = new AtomicInteger();
 
-		PoolBuilder<PoolableTest> builder = PoolBuilder
+		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				//default maxUse is 5, but this test relies on it being 2
 				.from(Mono.defer(() -> Mono.just(new PoolableTest(newCount.incrementAndGet(), 2))))
 				.initialSize(2)
@@ -165,10 +163,10 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("fifoPools")
-	void smokeTestInScopeFifo(Function<PoolBuilder<PoolableTest>, Pool<PoolableTest>> configAdjuster) {
+	void smokeTestInScopeFifo(Function<PoolBuilder<PoolableTest, ?>, Pool<PoolableTest>> configAdjuster) {
 		AtomicInteger newCount = new AtomicInteger();
 
-		PoolBuilder<PoolableTest> builder = PoolBuilder
+		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				//default maxUse is 5, but this test relies on it being 2
 				.from(Mono.defer(() -> Mono.just(new PoolableTest(newCount.incrementAndGet(), 2))))
 				.initialSize(2)
@@ -228,10 +226,10 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("fifoPools")
-	void smokeTestAsyncFifo(Function<PoolBuilder<PoolableTest>, Pool<PoolableTest>> configAdjuster) throws InterruptedException {
+	void smokeTestAsyncFifo(Function<PoolBuilder<PoolableTest, ?>, Pool<PoolableTest>> configAdjuster) throws InterruptedException {
 		AtomicInteger newCount = new AtomicInteger();
 
-		PoolBuilder<PoolableTest> builder = PoolBuilder
+		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				//default maxUse is 5, but this test relies on it being 2
 				.from(Mono.defer(() -> Mono.just(new PoolableTest(newCount.incrementAndGet(), 2)))
 				          .subscribeOn(Schedulers.newParallel("poolable test allocator")))
@@ -302,13 +300,13 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("lifoPools")
-	void simpleLifo(Function<PoolBuilder<PoolableTest>, AbstractPool<PoolableTest>> configAdjuster)
+	void simpleLifo(Function<PoolBuilder<PoolableTest, ?>, AbstractPool<PoolableTest>> configAdjuster)
 			throws InterruptedException {
 		CountDownLatch latch = new CountDownLatch(2);
 		AtomicInteger verif = new AtomicInteger();
 		AtomicInteger newCount = new AtomicInteger();
 
-		PoolBuilder<PoolableTest> builder =
+		PoolBuilder<PoolableTest, ?> builder =
 				PoolBuilder.from(Mono.defer(() ->
 						Mono.just(new PoolableTest(newCount.incrementAndGet()))))
 				           .sizeMax(1)
@@ -343,9 +341,9 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("lifoPools")
-	void smokeTestLifo(Function<PoolBuilder<PoolableTest>, AbstractPool<PoolableTest>> configAdjuster) throws InterruptedException {
+	void smokeTestLifo(Function<PoolBuilder<PoolableTest, ?>, AbstractPool<PoolableTest>> configAdjuster) throws InterruptedException {
 		AtomicInteger newCount = new AtomicInteger();
-		PoolBuilder<PoolableTest> builder = PoolBuilder
+		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				//default maxUse is 5, but this test relies on it being 2
 				.from(Mono.defer(() -> Mono.just(new PoolableTest(newCount.incrementAndGet(), 2))))
 				.initialSize(2)
@@ -396,9 +394,9 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("lifoPools")
-	void smokeTestInScopeLifo(Function<PoolBuilder<PoolableTest>, AbstractPool<PoolableTest>> configAdjuster) {
+	void smokeTestInScopeLifo(Function<PoolBuilder<PoolableTest, ?>, AbstractPool<PoolableTest>> configAdjuster) {
 		AtomicInteger newCount = new AtomicInteger();
-		PoolBuilder<PoolableTest> builder =
+		PoolBuilder<PoolableTest, ?> builder =
 				//default maxUse is 5, but this test relies on it being 2
 				PoolBuilder.from(Mono.defer(() -> Mono.just(new PoolableTest(newCount.incrementAndGet(), 2))))
 				           .initialSize(2)
@@ -460,10 +458,10 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("lifoPools")
-	void smokeTestAsyncLifo(Function<PoolBuilder<PoolableTest>, AbstractPool<PoolableTest>> configAdjuster) throws InterruptedException {
+	void smokeTestAsyncLifo(Function<PoolBuilder<PoolableTest, ?>, AbstractPool<PoolableTest>> configAdjuster) throws InterruptedException {
 		AtomicInteger newCount = new AtomicInteger();
 
-		PoolBuilder<PoolableTest> builder = PoolBuilder
+		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				//default maxUse is 5, but this test relies on it being 2
 				.from(Mono.defer(() -> Mono.just(new PoolableTest(newCount.incrementAndGet(), 2)))
 				          .subscribeOn(Schedulers.newParallel(
@@ -535,10 +533,10 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void returnedNotReleasedIfBorrowerCancelledEarly(Function<PoolBuilder<PoolableTest>, Pool<PoolableTest>> configAdjuster) {
+	void returnedNotReleasedIfBorrowerCancelledEarly(Function<PoolBuilder<PoolableTest, ?>, Pool<PoolableTest>> configAdjuster) {
 		AtomicInteger releasedCount = new AtomicInteger();
 
-		PoolBuilder<PoolableTest> builder = PoolBuilder
+		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(PoolableTest::new))
 				.initialSize(1)
 				.sizeMax(1)
@@ -566,11 +564,11 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void fixedPoolReplenishOnDestroy(Function<PoolBuilder<PoolableTest>, Pool<PoolableTest>> configAdjuster) throws Exception{
+	void fixedPoolReplenishOnDestroy(Function<PoolBuilder<PoolableTest, ?>, Pool<PoolableTest>> configAdjuster) throws Exception{
 		AtomicInteger releasedCount = new AtomicInteger();
 		AtomicInteger destroyedCount = new AtomicInteger();
 
-		PoolBuilder<PoolableTest> builder = PoolBuilder
+		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(PoolableTest::new))
 				.initialSize(1)
 				.sizeMax(1)
@@ -614,9 +612,9 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void returnedNotReleasedIfBorrowerInScopeCancelledEarly(Function<PoolBuilder<PoolableTest>, Pool<PoolableTest>> configAdjuster) {
+	void returnedNotReleasedIfBorrowerInScopeCancelledEarly(Function<PoolBuilder<PoolableTest, ?>, Pool<PoolableTest>> configAdjuster) {
 		AtomicInteger releasedCount = new AtomicInteger();
-		PoolBuilder<PoolableTest> builder =
+		PoolBuilder<PoolableTest, ?> builder =
 				PoolBuilder.from(Mono.fromCallable(PoolableTest::new))
 				           .initialSize(1)
 				           .sizeMax(1)
@@ -644,12 +642,12 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void allocatedReleasedIfBorrowerCancelled(Function<PoolBuilder<PoolableTest>, Pool<PoolableTest>> configAdjuster) {
+	void allocatedReleasedIfBorrowerCancelled(Function<PoolBuilder<PoolableTest, ?>, Pool<PoolableTest>> configAdjuster) {
 		Scheduler scheduler = Schedulers.newParallel("poolable test allocator");
 		AtomicInteger newCount = new AtomicInteger();
 		AtomicInteger releasedCount = new AtomicInteger();
 
-		PoolBuilder<PoolableTest> builder = PoolBuilder
+		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				.from(Mono.defer(() -> Mono.delay(Duration.ofMillis(50)).thenReturn(new PoolableTest(newCount.incrementAndGet())))
 				          .subscribeOn(scheduler))
 				.sizeMax(1)
@@ -677,12 +675,12 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void allocatedReleasedIfBorrowerInScopeCancelled(Function<PoolBuilder<PoolableTest>, Pool<PoolableTest>> configAdjuster) {
+	void allocatedReleasedIfBorrowerInScopeCancelled(Function<PoolBuilder<PoolableTest, ?>, Pool<PoolableTest>> configAdjuster) {
 		Scheduler scheduler = Schedulers.newParallel("poolable test allocator");
 		AtomicInteger newCount = new AtomicInteger();
 		AtomicInteger releasedCount = new AtomicInteger();
 
-		PoolBuilder<PoolableTest> builder =
+		PoolBuilder<PoolableTest, ?> builder =
 				PoolBuilder.from(Mono.defer(() -> Mono.delay(Duration.ofMillis(50)).thenReturn(new PoolableTest(newCount.incrementAndGet())))
 				                     .subscribeOn(scheduler))
 				           .initialSize(0)
@@ -709,12 +707,12 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void pendingLimitSync(Function<PoolBuilder<Integer>, AbstractPool<Integer>> configAdjuster) {
+	void pendingLimitSync(Function<PoolBuilder<Integer, ?>, AbstractPool<Integer>> configAdjuster) {
 		AtomicInteger allocatorCount = new AtomicInteger();
 		Disposable.Composite composite = Disposables.composite();
 
 		try {
-			PoolBuilder<Integer> builder = PoolBuilder.from(Mono.fromCallable(allocatorCount::incrementAndGet))
+			PoolBuilder<Integer, ?> builder = PoolBuilder.from(Mono.fromCallable(allocatorCount::incrementAndGet))
 			                                          .sizeMax(1)
 			                                          .initialSize(1)
 			                                          .maxPendingAcquire(1);
@@ -757,12 +755,12 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void pendingLimitAsync(Function<PoolBuilder<Integer>, AbstractPool<Integer>> configAdjuster) {
+	void pendingLimitAsync(Function<PoolBuilder<Integer, ?>, AbstractPool<Integer>> configAdjuster) {
 		AtomicInteger allocatorCount = new AtomicInteger();
 		final Disposable.Composite composite = Disposables.composite();
 
 		try {
-			PoolBuilder<Integer> builder = PoolBuilder.from(Mono.fromCallable(allocatorCount::incrementAndGet))
+			PoolBuilder<Integer, ?> builder = PoolBuilder.from(Mono.fromCallable(allocatorCount::incrementAndGet))
 			                                          .sizeMax(1)
 			                                          .initialSize(1)
 			                                          .maxPendingAcquire(1);
@@ -804,8 +802,8 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void cleanerFunctionError(Function<PoolBuilder<PoolableTest>, Pool<PoolableTest>> configAdjuster) {
-		PoolBuilder<PoolableTest> builder = PoolBuilder
+	void cleanerFunctionError(Function<PoolBuilder<PoolableTest, ?>, Pool<PoolableTest>> configAdjuster) {
+		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(PoolableTest::new))
 				.sizeMax(1)
 				.releaseHandler(poolableTest -> Mono.fromRunnable(() -> {
@@ -826,8 +824,8 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void cleanerFunctionErrorDiscards(Function<PoolBuilder<PoolableTest>, Pool<PoolableTest>> configAdjuster) {
-		PoolBuilder<PoolableTest> builder = PoolBuilder
+	void cleanerFunctionErrorDiscards(Function<PoolBuilder<PoolableTest, ?>, Pool<PoolableTest>> configAdjuster) {
+		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(PoolableTest::new))
 				.sizeMax(1)
 				.releaseHandler(poolableTest -> Mono.fromRunnable(() -> {
@@ -851,10 +849,10 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void disposingPoolDisposesElements(Function<PoolBuilder<PoolableTest>, AbstractPool<PoolableTest>> configAdjuster) {
+	void disposingPoolDisposesElements(Function<PoolBuilder<PoolableTest, ?>, AbstractPool<PoolableTest>> configAdjuster) {
 		AtomicInteger cleanerCount = new AtomicInteger();
 
-		PoolBuilder<PoolableTest> builder = PoolBuilder
+		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(PoolableTest::new))
 				.sizeMax(3)
 				.releaseHandler(p -> Mono.fromRunnable(cleanerCount::incrementAndGet))
@@ -881,9 +879,9 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void disposingPoolFailsPendingBorrowers(Function<PoolBuilder<PoolableTest>, AbstractPool<PoolableTest>> configAdjuster) {
+	void disposingPoolFailsPendingBorrowers(Function<PoolBuilder<PoolableTest, ?>, AbstractPool<PoolableTest>> configAdjuster) {
 		AtomicInteger cleanerCount = new AtomicInteger();
-		PoolBuilder<PoolableTest> builder = PoolBuilder
+		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(PoolableTest::new))
 				.sizeMax(3)
 				.initialSize(3)
@@ -921,9 +919,9 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void releasingToDisposedPoolDisposesElement(Function<PoolBuilder<PoolableTest>, AbstractPool<PoolableTest>> configAdjuster) {
+	void releasingToDisposedPoolDisposesElement(Function<PoolBuilder<PoolableTest, ?>, AbstractPool<PoolableTest>> configAdjuster) {
 		AtomicInteger cleanerCount = new AtomicInteger();
-		PoolBuilder<PoolableTest> builder = PoolBuilder
+		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(PoolableTest::new))
 				.sizeMax(3)
 				.initialSize(3)
@@ -955,9 +953,9 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void acquiringFromDisposedPoolFailsBorrower(Function<PoolBuilder<PoolableTest>, AbstractPool<PoolableTest>> configAdjuster) {
+	void acquiringFromDisposedPoolFailsBorrower(Function<PoolBuilder<PoolableTest, ?>, AbstractPool<PoolableTest>> configAdjuster) {
 		AtomicInteger cleanerCount = new AtomicInteger();
-		PoolBuilder<PoolableTest> builder = PoolBuilder
+		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(PoolableTest::new))
 				.sizeMax(3)
 				.releaseHandler(p -> Mono.fromRunnable(cleanerCount::incrementAndGet))
@@ -976,8 +974,8 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void poolIsDisposed(Function<PoolBuilder<PoolableTest>, AbstractPool<PoolableTest>> configAdjuster) {
-		PoolBuilder<PoolableTest> builder = PoolBuilder
+	void poolIsDisposed(Function<PoolBuilder<PoolableTest, ?>, AbstractPool<PoolableTest>> configAdjuster) {
+		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(PoolableTest::new))
 				.sizeMax(3)
 				.evictionPredicate((poolable, metadata) -> !poolable.isHealthy());
@@ -992,10 +990,10 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void disposingPoolClosesCloseable(Function<PoolBuilder<Formatter>, AbstractPool<Formatter>> configAdjuster) {
+	void disposingPoolClosesCloseable(Function<PoolBuilder<Formatter, ?>, AbstractPool<Formatter>> configAdjuster) {
 		Formatter uniqueElement = new Formatter();
 
-		PoolBuilder<Formatter> builder = PoolBuilder
+		PoolBuilder<Formatter, ?> builder = PoolBuilder
 				.from(Mono.just(uniqueElement))
 				.sizeMax(1)
 				.initialSize(1)
@@ -1010,10 +1008,10 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void disposeLaterIsLazy(Function<PoolBuilder<Formatter>, AbstractPool<Formatter>> configAdjuster) {
+	void disposeLaterIsLazy(Function<PoolBuilder<Formatter, ?>, AbstractPool<Formatter>> configAdjuster) {
 		Formatter uniqueElement = new Formatter();
 
-		PoolBuilder<Formatter> builder = PoolBuilder
+		PoolBuilder<Formatter, ?> builder = PoolBuilder
 				.from(Mono.just(uniqueElement))
 				.sizeMax(1)
 				.initialSize(1)
@@ -1032,11 +1030,11 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void disposeLaterCompletesWhenAllReleased(Function<PoolBuilder<AtomicBoolean>, AbstractPool<AtomicBoolean>> configAdjuster) {
+	void disposeLaterCompletesWhenAllReleased(Function<PoolBuilder<AtomicBoolean, ?>, AbstractPool<AtomicBoolean>> configAdjuster) {
 		List<AtomicBoolean> elements = Arrays.asList(new AtomicBoolean(), new AtomicBoolean(), new AtomicBoolean());
 		AtomicInteger index = new AtomicInteger(0);
 
-		PoolBuilder<AtomicBoolean> builder = PoolBuilder
+		PoolBuilder<AtomicBoolean, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(() -> elements.get(index.getAndIncrement())))
 				.sizeMax(3)
 				.initialSize(3)
@@ -1055,10 +1053,10 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void disposeLaterReleasedConcurrently(Function<PoolBuilder<Integer>, AbstractPool<Integer>> configAdjuster) {
+	void disposeLaterReleasedConcurrently(Function<PoolBuilder<Integer, ?>, AbstractPool<Integer>> configAdjuster) {
 		AtomicInteger live = new AtomicInteger(0);
 
-		PoolBuilder<Integer> builder = PoolBuilder
+		PoolBuilder<Integer, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(live::getAndIncrement))
 				.sizeMax(3)
 				.initialSize(3)
@@ -1080,8 +1078,8 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void allocatorErrorOutsideConstructorIsPropagated(Function<PoolBuilder<String>, AbstractPool<String>> configAdjuster) {
-		PoolBuilder<String> builder = PoolBuilder
+	void allocatorErrorOutsideConstructorIsPropagated(Function<PoolBuilder<String, ?>, AbstractPool<String>> configAdjuster) {
+		PoolBuilder<String, ?> builder = PoolBuilder
 				.from(Mono.<String>error(new IllegalStateException("boom")))
 				.sizeMax(1)
 				.initialSize(0)
@@ -1095,8 +1093,8 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void allocatorErrorInConstructorIsThrown(Function<PoolBuilder<Object>, AbstractPool<Object>> configAdjuster) {
-		final PoolBuilder<Object> builder = PoolBuilder
+	void allocatorErrorInConstructorIsThrown(Function<PoolBuilder<Object, ?>, AbstractPool<Object>> configAdjuster) {
+		final PoolBuilder<Object, ?> builder = PoolBuilder
 				.from(Mono.error(new IllegalStateException("boom")))
 				.initialSize(1)
 				.sizeMax(1)
@@ -1109,7 +1107,7 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void discardCloseableWhenCloseFailureLogs(Function<PoolBuilder<Closeable>, AbstractPool<Closeable>> configAdjuster) {
+	void discardCloseableWhenCloseFailureLogs(Function<PoolBuilder<Closeable, ?>, AbstractPool<Closeable>> configAdjuster) {
 		TestLogger testLogger = new TestLogger();
 		Loggers.useCustomLoggers(it -> testLogger);
 		try {
@@ -1117,7 +1115,7 @@ public class CommonPoolTest {
 				throw new IOException("boom");
 			};
 
-			PoolBuilder<Closeable> builder = PoolBuilder
+			PoolBuilder<Closeable, ?> builder = PoolBuilder
 					.from(Mono.just(closeable))
 					.initialSize(1)
 					.sizeMax(1)
@@ -1136,11 +1134,11 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void pendingTimeoutNotImpactedByLongAllocation(Function<PoolBuilder<String>, AbstractPool<String>> configAdjuster) {
+	void pendingTimeoutNotImpactedByLongAllocation(Function<PoolBuilder<String, ?>, AbstractPool<String>> configAdjuster) {
 		VirtualTimeScheduler vts1 = VirtualTimeScheduler.getOrSet();
 
 		try {
-			PoolBuilder<String> builder = PoolBuilder
+			PoolBuilder<String, ?> builder = PoolBuilder
 					.from(Mono.just("delayed").delaySubscription(Duration.ofMillis(500)))
 					.sizeMax(1);
 			AbstractPool<String> pool = configAdjuster.apply(builder);
@@ -1176,8 +1174,8 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void pendingTimeoutImpactedByLongRelease(Function<PoolBuilder<String>, AbstractPool<String>> configAdjuster) {
-		PoolBuilder<String> builder = PoolBuilder
+	void pendingTimeoutImpactedByLongRelease(Function<PoolBuilder<String, ?>, AbstractPool<String>> configAdjuster) {
+		PoolBuilder<String, ?> builder = PoolBuilder
 				.from(Mono.just("instant"))
 				.sizeMax(1);
 		AbstractPool<String> pool = configAdjuster.apply(builder);
@@ -1196,9 +1194,9 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
-	void pendingTimeoutDoesntCauseExtraReleasePostTimeout(Function<PoolBuilder<AtomicInteger>, AbstractPool<AtomicInteger>> configAdjuster) {
+	void pendingTimeoutDoesntCauseExtraReleasePostTimeout(Function<PoolBuilder<AtomicInteger, ?>, AbstractPool<AtomicInteger>> configAdjuster) {
 		AtomicInteger resource = new AtomicInteger();
-		PoolBuilder<AtomicInteger> builder = PoolBuilder
+		PoolBuilder<AtomicInteger, ?> builder = PoolBuilder
 				.from(Mono.just(resource))
 				.releaseHandler(atomic -> Mono.fromRunnable(atomic::incrementAndGet))
 				.sizeMax(1);
@@ -1234,10 +1232,10 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void recordsAllocationCountInConstructor(Function<PoolBuilder<String>, AbstractPool<String>> configAdjuster) {
+	void recordsAllocationCountInConstructor(Function<PoolBuilder<String, ?>, AbstractPool<String>> configAdjuster) {
 		AtomicBoolean flip = new AtomicBoolean();
 		//note the starter method here is irrelevant, only the config is created and passed to createPool
-		PoolBuilder<String> builder = PoolBuilder
+		PoolBuilder<String, ?> builder = PoolBuilder
 				.from(Mono.defer(() -> {
 					if (flip.compareAndSet(false, true)) {
 						return Mono.just("foo");
@@ -1265,10 +1263,10 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void recordsAllocationCountInBorrow(Function<PoolBuilder<String>, AbstractPool<String>> configAdjuster) {
+	void recordsAllocationCountInBorrow(Function<PoolBuilder<String, ?>, AbstractPool<String>> configAdjuster) {
 		AtomicBoolean flip = new AtomicBoolean();
 		//note the starter method here is irrelevant, only the config is created and passed to createPool
-		PoolBuilder<String> builder = PoolBuilder
+		PoolBuilder<String, ?> builder = PoolBuilder
 				.from(Mono.defer(() -> {
 					if (flip.compareAndSet(false, true)) {
 						return Mono.just("foo");
@@ -1307,10 +1305,10 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void recordsAllocationLatenciesInConstructor(Function<PoolBuilder<String>, AbstractPool<String>> configAdjuster) {
+	void recordsAllocationLatenciesInConstructor(Function<PoolBuilder<String, ?>, AbstractPool<String>> configAdjuster) {
 		AtomicBoolean flip = new AtomicBoolean();
 		//note the starter method here is irrelevant, only the config is created and passed to createPool
-		PoolBuilder<String> builder = PoolBuilder
+		PoolBuilder<String, ?> builder = PoolBuilder
 				.from(Mono.defer(() -> {
 					if (flip.compareAndSet(false, true)) {
 						return Mono.just("foo").delayElement(Duration.ofMillis(100));
@@ -1338,10 +1336,10 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void recordsAllocationLatenciesInBorrow(Function<PoolBuilder<String>, AbstractPool<String>> configAdjuster) {
+	void recordsAllocationLatenciesInBorrow(Function<PoolBuilder<String, ?>, AbstractPool<String>> configAdjuster) {
 		AtomicBoolean flip = new AtomicBoolean();
 		//note the starter method here is irrelevant, only the config is created and passed to createPool
-		PoolBuilder<String> builder = PoolBuilder
+		PoolBuilder<String, ?> builder = PoolBuilder
 				.from(Mono.defer(() -> {
 					if (flip.compareAndSet(false, true)) {
 						return Mono.just("foo").delayElement(Duration.ofMillis(100));
@@ -1372,10 +1370,10 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void recordsResetLatencies(Function<PoolBuilder<String>, AbstractPool<String>> configAdjuster) {
+	void recordsResetLatencies(Function<PoolBuilder<String, ?>, AbstractPool<String>> configAdjuster) {
 		AtomicBoolean flip = new AtomicBoolean();
 		//note the starter method here is irrelevant, only the config is created and passed to createPool
-		PoolBuilder<String> builder = PoolBuilder
+		PoolBuilder<String, ?> builder = PoolBuilder
 				.from(Mono.just("foo"))
 				.releaseHandler(s -> {
 					if (flip.compareAndSet(false,
@@ -1408,10 +1406,10 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void recordsDestroyLatencies(Function<PoolBuilder<String>, AbstractPool<String>> configAdjuster) {
+	void recordsDestroyLatencies(Function<PoolBuilder<String, ?>, AbstractPool<String>> configAdjuster) {
 		AtomicBoolean flip = new AtomicBoolean();
 		//note the starter method here is irrelevant, only the config is created and passed to createPool
-		PoolBuilder<String> builder = PoolBuilder
+		PoolBuilder<String, ?> builder = PoolBuilder
 				.from(Mono.just("foo"))
 				.evictionPredicate((poolable, metadata) -> true)
 				.destroyHandler(s -> {
@@ -1449,10 +1447,10 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void recordsResetVsRecycle(Function<PoolBuilder<String>, AbstractPool<String>> configAdjuster) {
+	void recordsResetVsRecycle(Function<PoolBuilder<String, ?>, AbstractPool<String>> configAdjuster) {
 		AtomicReference<String> content = new AtomicReference<>("foo");
 		//note the starter method here is irrelevant, only the config is created and passed to createPool
-		PoolBuilder<String> builder = PoolBuilder
+		PoolBuilder<String, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(() -> content.getAndSet("bar")))
 				.evictionPredicate((poolable, metadata) -> "foo".equals(poolable))
 				.metricsRecorder(recorder);
@@ -1469,11 +1467,11 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void recordsLifetime(Function<PoolBuilder<Integer>, AbstractPool<Integer>> configAdjuster) throws InterruptedException {
+	void recordsLifetime(Function<PoolBuilder<Integer, ?>, AbstractPool<Integer>> configAdjuster) throws InterruptedException {
 		AtomicInteger allocCounter = new AtomicInteger();
 		AtomicInteger destroyCounter = new AtomicInteger();
 		//note the starter method here is irrelevant, only the config is created and passed to createPool
-		PoolBuilder<Integer> builder = PoolBuilder
+		PoolBuilder<Integer, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(allocCounter::incrementAndGet))
 				.sizeMax(2)
 				.evictionPredicate((poolable, metadata) -> metadata.acquireCount() >= 2)
@@ -1508,10 +1506,10 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void recordsIdleTimeFromConstructor(Function<PoolBuilder<Integer>, AbstractPool<Integer>> configAdjuster) throws InterruptedException {
+	void recordsIdleTimeFromConstructor(Function<PoolBuilder<Integer, ?>, AbstractPool<Integer>> configAdjuster) throws InterruptedException {
 		AtomicInteger allocCounter = new AtomicInteger();
 		//note the starter method here is irrelevant, only the config is created and passed to createPool
-		PoolBuilder<Integer> builder = PoolBuilder
+		PoolBuilder<Integer, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(allocCounter::incrementAndGet))
 				.sizeMax(2)
 				.initialSize(2)
@@ -1538,10 +1536,10 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void recordsIdleTimeBetweenAcquires(Function<PoolBuilder<Integer>, AbstractPool<Integer>> configAdjuster) throws InterruptedException {
+	void recordsIdleTimeBetweenAcquires(Function<PoolBuilder<Integer, ?>, AbstractPool<Integer>> configAdjuster) throws InterruptedException {
 		AtomicInteger allocCounter = new AtomicInteger();
 		//note the starter method here is irrelevant, only the config is created and passed to createPool
-		PoolBuilder<Integer> builder = PoolBuilder
+		PoolBuilder<Integer, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(allocCounter::incrementAndGet))
 				.sizeMax(2)
 				.initialSize(2)
@@ -1580,11 +1578,11 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void acquireTimeout(Function<PoolBuilder<Integer>, AbstractPool<Integer>> configAdjuster) {
+	void acquireTimeout(Function<PoolBuilder<Integer, ?>, AbstractPool<Integer>> configAdjuster) {
 		AtomicInteger allocCounter = new AtomicInteger();
 		AtomicInteger didReset = new AtomicInteger();
 		//note the starter method here is irrelevant, only the config is created and passed to createPool
-		PoolBuilder<Integer> builder = PoolBuilder
+		PoolBuilder<Integer, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(allocCounter::incrementAndGet))
 				.releaseHandler(i -> Mono.fromRunnable(didReset::incrementAndGet))
 				.sizeMax(1);
@@ -1611,8 +1609,8 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void instrumentedPoolsMetricsAreSelfViews(Function<PoolBuilder<Integer>, AbstractPool<Integer>> configAdjuster) {
-		PoolBuilder<Integer> builder = PoolBuilder.from(Mono.just(1));
+	void instrumentedPoolsMetricsAreSelfViews(Function<PoolBuilder<Integer, ?>, AbstractPool<Integer>> configAdjuster) {
+		PoolBuilder<Integer, ?> builder = PoolBuilder.from(Mono.just(1));
 		Pool<Integer> pool = configAdjuster.apply(builder);
 
 		assertThat(pool).isInstanceOf(InstrumentedPool.class);
@@ -1625,8 +1623,8 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void instrumentAllocatedIdleAcquired(Function<PoolBuilder<Integer>, AbstractPool<Integer>> configAdjuster) {
-		PoolBuilder<Integer> builder = PoolBuilder.from(Mono.just(1))
+	void instrumentAllocatedIdleAcquired(Function<PoolBuilder<Integer, ?>, AbstractPool<Integer>> configAdjuster) {
+		PoolBuilder<Integer, ?> builder = PoolBuilder.from(Mono.just(1))
 				.sizeMax(1);
 		InstrumentedPool<Integer> pool = configAdjuster.apply(builder);
 		PoolMetrics poolMetrics = pool.metrics();
@@ -1649,9 +1647,9 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void instrumentAllocatedIdleAcquired_1(Function<PoolBuilder<Integer>, AbstractPool<Integer>> configAdjuster)
+	void instrumentAllocatedIdleAcquired_1(Function<PoolBuilder<Integer, ?>, AbstractPool<Integer>> configAdjuster)
 			throws Exception {
-		PoolBuilder<Integer> builder = PoolBuilder.from(Mono.just(1))
+		PoolBuilder<Integer, ?> builder = PoolBuilder.from(Mono.just(1))
 				.sizeMax(1);
 		InstrumentedPool<Integer> pool = configAdjuster.apply(builder);
 		PoolMetrics poolMetrics = pool.metrics();
@@ -1699,8 +1697,8 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void instrumentPendingAcquire(Function<PoolBuilder<Integer>, AbstractPool<Integer>> configAdjuster) {
-		PoolBuilder<Integer> builder = PoolBuilder.from(Mono.just(1))
+	void instrumentPendingAcquire(Function<PoolBuilder<Integer, ?>, AbstractPool<Integer>> configAdjuster) {
+		PoolBuilder<Integer, ?> builder = PoolBuilder.from(Mono.just(1))
 				.sizeMax(1);
 		InstrumentedPool<Integer> pool = configAdjuster.apply(builder);
 		PoolMetrics poolMetrics = pool.metrics();
@@ -1722,8 +1720,8 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void getConfigMaxPendingAcquire(Function<PoolBuilder<Integer>, AbstractPool<Integer>> configAdjuster) {
-		PoolBuilder<Integer> builder = PoolBuilder.from(Mono.just(1))
+	void getConfigMaxPendingAcquire(Function<PoolBuilder<Integer, ?>, AbstractPool<Integer>> configAdjuster) {
+		PoolBuilder<Integer, ?> builder = PoolBuilder.from(Mono.just(1))
 		                                          .maxPendingAcquire(12);
 		InstrumentedPool<Integer> pool = configAdjuster.apply(builder);
 		PoolMetrics poolMetrics = pool.metrics();
@@ -1734,8 +1732,8 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void getConfigMaxPendingAcquireUnbounded(Function<PoolBuilder<Integer>, AbstractPool<Integer>> configAdjuster) {
-		PoolBuilder<Integer> builder = PoolBuilder.from(Mono.just(1))
+	void getConfigMaxPendingAcquireUnbounded(Function<PoolBuilder<Integer, ?>, AbstractPool<Integer>> configAdjuster) {
+		PoolBuilder<Integer, ?> builder = PoolBuilder.from(Mono.just(1))
 		                                          .maxPendingAcquireUnbounded();
 		InstrumentedPool<Integer> pool = configAdjuster.apply(builder);
 		PoolMetrics poolMetrics = pool.metrics();
@@ -1746,8 +1744,8 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void getConfigMaxSize(Function<PoolBuilder<Integer>, AbstractPool<Integer>> configAdjuster) {
-		PoolBuilder<Integer> builder = PoolBuilder.from(Mono.just(1))
+	void getConfigMaxSize(Function<PoolBuilder<Integer, ?>, AbstractPool<Integer>> configAdjuster) {
+		PoolBuilder<Integer, ?> builder = PoolBuilder.from(Mono.just(1))
 		                                          .sizeMax(22);
 		InstrumentedPool<Integer> pool = configAdjuster.apply(builder);
 		PoolMetrics poolMetrics = pool.metrics();
@@ -1758,8 +1756,8 @@ public class CommonPoolTest {
 	@ParameterizedTest
 	@MethodSource("allPools")
 	@Tag("metrics")
-	void getConfigMaxSizeUnbounded(Function<PoolBuilder<Integer>, AbstractPool<Integer>> configAdjuster) {
-		PoolBuilder<Integer> builder = PoolBuilder.from(Mono.just(1))
+	void getConfigMaxSizeUnbounded(Function<PoolBuilder<Integer, ?>, AbstractPool<Integer>> configAdjuster) {
+		PoolBuilder<Integer, ?> builder = PoolBuilder.from(Mono.just(1))
 		                                          .sizeUnbounded();
 		InstrumentedPool<Integer> pool = configAdjuster.apply(builder);
 		PoolMetrics poolMetrics = pool.metrics();

--- a/src/test/java/reactor/pool/PoolBuilderTest.java
+++ b/src/test/java/reactor/pool/PoolBuilderTest.java
@@ -52,8 +52,8 @@ class PoolBuilderTest {
         AtomicInteger source = new AtomicInteger();
         final PublisherProbe<Integer> probe = PublisherProbe.of(Mono.fromCallable(source::incrementAndGet));
 
-        PoolBuilder<Integer> builder = PoolBuilder.from(probe.mono());
-        final AbstractPool.DefaultPoolConfig<Integer> config = builder.buildConfig();
+        PoolBuilder<Integer, PoolConfig<Integer>> builder = PoolBuilder.from(probe.mono());
+        final PoolConfig<Integer> config = builder.buildConfig();
 
         StepVerifier.create(config.allocator)
                     .expectNext(1)
@@ -68,8 +68,8 @@ class PoolBuilderTest {
         AtomicInteger source = new AtomicInteger();
         final PublisherProbe<Integer> probe = PublisherProbe.of(Mono.fromCallable(source::incrementAndGet).repeat(3));
 
-        PoolBuilder<Integer> builder = PoolBuilder.from(probe.flux());
-        final AbstractPool.DefaultPoolConfig<Integer> config = builder.buildConfig();
+        PoolBuilder<Integer, PoolConfig<Integer>> builder = PoolBuilder.from(probe.flux());
+        final PoolConfig<Integer> config = builder.buildConfig();
 
         StepVerifier.create(config.allocator)
                     .expectNext(1)
@@ -85,8 +85,8 @@ class PoolBuilderTest {
         Flowable<Integer> source = Flowable.range(1, 4)
                                   .doOnCancel(() -> cancelled.set(true));
 
-        PoolBuilder<Integer> builder = PoolBuilder.from(source);
-        final AbstractPool.DefaultPoolConfig<Integer> config = builder.buildConfig();
+        PoolBuilder<Integer, PoolConfig<Integer>> builder = PoolBuilder.from(source);
+        final PoolConfig<Integer> config = builder.buildConfig();
 
         StepVerifier.create(config.allocator)
                     .expectNext(1)
@@ -100,11 +100,85 @@ class PoolBuilderTest {
         Mono<Long> source = Flux.range(1, 10).count();
         Predicate<Number> numberPredicate = n -> n.intValue() == 10;
 
-        PoolBuilder<Number> poolBuilder = PoolBuilder.from(source);
-        AbstractPool.DefaultPoolConfig<Number> config = poolBuilder.buildConfig();
+        PoolBuilder<Number, PoolConfig<Number>> poolBuilder = PoolBuilder.from(source);
+        PoolConfig<Number> config = poolBuilder.buildConfig();
 
         StepVerifier.create(config.allocator)
                     .assertNext(n -> assertThat(n).matches(numberPredicate))
                     .verifyComplete();
+    }
+
+    @Test
+    void customizedConfig() {
+        FooBarOnlyPool<String> customPool =
+                PoolBuilder.from(Mono.just("hello"))
+                           .extraConfiguration(it -> new FooExtraConfig<>(it).foo(true))
+                           .extraConfiguration(fc -> new FooBarExtraConfig<>(fc).bar(true))
+                           .build(FooBarOnlyPool::new);
+
+        assertThat(customPool.config.isBar()).as("bar").isTrue();
+        assertThat(customPool.config.isFoo()).as("foo").isTrue();
+    }
+
+    static class FooBarOnlyPool<T> implements Pool<T> {
+
+        private final FooBarExtraConfig<T> config;
+
+        public FooBarOnlyPool(FooBarExtraConfig<T> config) {
+            this.config = config;
+        }
+
+        @Override
+        public Mono<PooledRef<T>> acquire() {
+            return null;
+        }
+
+        @Override
+        public Mono<PooledRef<T>> acquire(Duration timeout) {
+            return null;
+        }
+
+        @Override
+        public Mono<Void> disposeLater() {
+            return null;
+        }
+    }
+
+    static class FooExtraConfig<T> extends PoolConfig<T> {
+
+        private boolean isFoo = false;
+
+        FooExtraConfig(PoolConfig<T> toCopy) {
+            super(toCopy);
+        }
+
+        public FooExtraConfig<T> foo(boolean isFoo) {
+            this.isFoo = isFoo;
+            return this;
+        }
+
+        public boolean isFoo() {
+            return isFoo;
+        }
+    }
+
+    static class FooBarExtraConfig<T> extends FooExtraConfig<T> {
+
+        private boolean isBar;
+
+        public FooBarExtraConfig(FooExtraConfig<T> toCopy) {
+            super(toCopy);
+            foo(toCopy.isFoo);
+            this.isBar = false;
+        }
+
+        public FooBarExtraConfig<T> bar(boolean isBar) {
+            this.isBar = isBar;
+            return this;
+        }
+
+        public boolean isBar() {
+            return isBar;
+        }
     }
 }

--- a/src/test/java/reactor/pool/PoolBuilderTest.java
+++ b/src/test/java/reactor/pool/PoolBuilderTest.java
@@ -55,7 +55,7 @@ class PoolBuilderTest {
         PoolBuilder<Integer, PoolConfig<Integer>> builder = PoolBuilder.from(probe.mono());
         final PoolConfig<Integer> config = builder.buildConfig();
 
-        StepVerifier.create(config.allocator)
+        StepVerifier.create(config.allocator())
                     .expectNext(1)
                     .verifyComplete();
 
@@ -71,7 +71,7 @@ class PoolBuilderTest {
         PoolBuilder<Integer, PoolConfig<Integer>> builder = PoolBuilder.from(probe.flux());
         final PoolConfig<Integer> config = builder.buildConfig();
 
-        StepVerifier.create(config.allocator)
+        StepVerifier.create(config.allocator())
                     .expectNext(1)
                     .verifyComplete();
 
@@ -88,7 +88,7 @@ class PoolBuilderTest {
         PoolBuilder<Integer, PoolConfig<Integer>> builder = PoolBuilder.from(source);
         final PoolConfig<Integer> config = builder.buildConfig();
 
-        StepVerifier.create(config.allocator)
+        StepVerifier.create(config.allocator())
                     .expectNext(1)
                     .verifyComplete();
 
@@ -103,7 +103,7 @@ class PoolBuilderTest {
         PoolBuilder<Number, PoolConfig<Number>> poolBuilder = PoolBuilder.from(source);
         PoolConfig<Number> config = poolBuilder.buildConfig();
 
-        StepVerifier.create(config.allocator)
+        StepVerifier.create(config.allocator())
                     .assertNext(n -> assertThat(n).matches(numberPredicate))
                     .verifyComplete();
     }
@@ -144,7 +144,7 @@ class PoolBuilderTest {
         }
     }
 
-    static class FooExtraConfig<T> extends PoolConfig<T> {
+    static class FooExtraConfig<T> extends DefaultPoolConfig<T> {
 
         private boolean isFoo = false;
 

--- a/src/test/java/reactor/pool/SimpleFifoPoolTest.java
+++ b/src/test/java/reactor/pool/SimpleFifoPoolTest.java
@@ -113,7 +113,7 @@ class SimpleFifoPoolTest {
         Thread.sleep(500);
         //we've finished processing, let's check resource has been automatically released
         assertThat(counter).as("after all emitted").hasValue(3);
-        assertThat(pool.poolConfig.allocationStrategy.estimatePermitCount()).as("allocation permits").isZero();
+        assertThat(pool.poolConfig.allocationStrategy().estimatePermitCount()).as("allocation permits").isZero();
         assertThat(pool.elements).as("available").hasSize(1);
         assertThat(releaseRef).as("released").hasValue("Hello Reactive World");
     }

--- a/src/test/java/reactor/pool/SimpleLifoPoolTest.java
+++ b/src/test/java/reactor/pool/SimpleLifoPoolTest.java
@@ -116,7 +116,7 @@ class SimpleLifoPoolTest {
         Thread.sleep(500);
         //we've finished processing, let's check resource has been automatically released
         assertThat(counter).as("after all emitted").hasValue(3);
-        assertThat(pool.poolConfig.allocationStrategy.estimatePermitCount()).as("allocation permits").isZero();
+        assertThat(pool.poolConfig.allocationStrategy().estimatePermitCount()).as("allocation permits").isZero();
         assertThat(pool.elements).as("available").hasSize(1);
         assertThat(releaseRef).as("released").hasValue("Hello Reactive World");
     }

--- a/src/test/java/reactor/pool/SimpleLifoPoolTest.java
+++ b/src/test/java/reactor/pool/SimpleLifoPoolTest.java
@@ -37,7 +37,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
-import reactor.pool.AbstractPool.DefaultPoolConfig;
 import reactor.pool.TestUtils.PoolableTest;
 import reactor.test.util.RaceTestUtils;
 import reactor.util.function.Tuple2;
@@ -54,9 +53,8 @@ class SimpleLifoPoolTest {
     //FIXME extract lifo-specific tests into CommonPoolTest
 
     //==utils for package-private config==
-    static final DefaultPoolConfig<PoolableTest> poolableTestConfig(int minSize, int maxSize, Mono<PoolableTest> allocator) {
+    static final PoolConfig<PoolableTest> poolableTestConfig(int minSize, int maxSize, Mono<PoolableTest> allocator) {
         return from(allocator)
-                .lifo(true)
                 .initialSize(minSize)
                 .sizeMax(maxSize)
                 .releaseHandler(pt -> Mono.fromRunnable(pt::clean))
@@ -64,9 +62,8 @@ class SimpleLifoPoolTest {
                 .buildConfig();
     }
 
-    static final DefaultPoolConfig<PoolableTest> poolableTestConfig(int minSize, int maxSize, Mono<PoolableTest> allocator, Scheduler deliveryScheduler) {
+    static final PoolConfig<PoolableTest> poolableTestConfig(int minSize, int maxSize, Mono<PoolableTest> allocator, Scheduler deliveryScheduler) {
         return from(allocator)
-                .lifo(true)
                 .initialSize(minSize)
                 .sizeMax(maxSize)
                 .releaseHandler(pt -> Mono.fromRunnable(pt::clean))
@@ -75,10 +72,9 @@ class SimpleLifoPoolTest {
                 .buildConfig();
     }
 
-    static final DefaultPoolConfig<PoolableTest> poolableTestConfig(int minSize, int maxSize, Mono<PoolableTest> allocator,
+    static final PoolConfig<PoolableTest> poolableTestConfig(int minSize, int maxSize, Mono<PoolableTest> allocator,
             Consumer<? super PoolableTest> additionalCleaner) {
         return from(allocator)
-                .lifo(true)
                 .initialSize(minSize)
                 .sizeMax(maxSize)
                 .releaseHandler(poolableTest -> Mono.fromRunnable(() -> {
@@ -97,7 +93,6 @@ class SimpleLifoPoolTest {
 
         SimpleLifoPool<String> pool = new SimpleLifoPool<>(
                 from(Mono.just("Hello Reactive World"))
-                        .lifo(true)
                         .sizeMax(1)
                         .releaseHandler(s -> Mono.fromRunnable(()-> releaseRef.set(s)))
                         .buildConfig());
@@ -152,7 +147,7 @@ class SimpleLifoPoolTest {
         void allocatedReleasedOrAbortedIfCancelRequestRace(int round, AtomicInteger newCount, AtomicInteger releasedCount, boolean cancelFirst) throws InterruptedException {
             Scheduler scheduler = Schedulers.newParallel("poolable test allocator");
 
-            DefaultPoolConfig<PoolableTest> testConfig = poolableTestConfig(0, 1,
+            PoolConfig<PoolableTest> testConfig = poolableTestConfig(0, 1,
                     Mono.defer(() -> Mono.delay(Duration.ofMillis(50)).thenReturn(new PoolableTest(newCount.incrementAndGet())))
                         .subscribeOn(scheduler),
                     pt -> releasedCount.incrementAndGet());
@@ -191,7 +186,7 @@ class SimpleLifoPoolTest {
         void defaultThreadDeliveringWhenHasElements() throws InterruptedException {
             AtomicReference<String> threadName = new AtomicReference<>();
             Scheduler acquireScheduler = Schedulers.newSingle("acquire");
-            DefaultPoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
+            PoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
                     Mono.fromCallable(PoolableTest::new)
                         .subscribeOn(Schedulers.newParallel("poolable test allocator")));
             SimpleLifoPool<PoolableTest> pool = new SimpleLifoPool<>(testConfig);
@@ -213,7 +208,7 @@ class SimpleLifoPoolTest {
         void defaultThreadDeliveringWhenNoElementsButNotFull() throws InterruptedException {
             AtomicReference<String> threadName = new AtomicReference<>();
             Scheduler acquireScheduler = Schedulers.newSingle("acquire");
-            DefaultPoolConfig<PoolableTest> testConfig = poolableTestConfig(0, 1,
+            PoolConfig<PoolableTest> testConfig = poolableTestConfig(0, 1,
                     Mono.fromCallable(PoolableTest::new)
                         .subscribeOn(Schedulers.newParallel("poolable test allocator")));
             SimpleLifoPool<PoolableTest> pool = new SimpleLifoPool<>(testConfig);
@@ -238,7 +233,7 @@ class SimpleLifoPoolTest {
             Scheduler acquireScheduler = Schedulers.newSingle("acquire");
             Scheduler releaseScheduler = Schedulers.fromExecutorService(
                     Executors.newSingleThreadScheduledExecutor((r -> new Thread(r,"release"))));
-            DefaultPoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
+            PoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
                     Mono.fromCallable(PoolableTest::new)
                         .subscribeOn(Schedulers.newParallel("poolable test allocator")));
             SimpleLifoPool<PoolableTest> pool = new SimpleLifoPool<>(testConfig);
@@ -270,7 +265,7 @@ class SimpleLifoPoolTest {
             Scheduler deliveryScheduler = Schedulers.newSingle("delivery");
             AtomicReference<String> threadName = new AtomicReference<>();
             Scheduler acquireScheduler = Schedulers.newSingle("acquire");
-            DefaultPoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
+            PoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
                     Mono.fromCallable(PoolableTest::new)
                         .subscribeOn(Schedulers.newParallel("poolable test allocator")),
                     deliveryScheduler);
@@ -294,7 +289,7 @@ class SimpleLifoPoolTest {
             Scheduler deliveryScheduler = Schedulers.newSingle("delivery");
             AtomicReference<String> threadName = new AtomicReference<>();
             Scheduler acquireScheduler = Schedulers.newSingle("acquire");
-            DefaultPoolConfig<PoolableTest> testConfig = poolableTestConfig(0, 1,
+            PoolConfig<PoolableTest> testConfig = poolableTestConfig(0, 1,
                     Mono.fromCallable(PoolableTest::new)
                         .subscribeOn(Schedulers.newParallel("poolable test allocator")),
                     deliveryScheduler);
@@ -321,7 +316,7 @@ class SimpleLifoPoolTest {
             Scheduler acquireScheduler = Schedulers.newSingle("acquire");
             Scheduler releaseScheduler = Schedulers.fromExecutorService(
                     Executors.newSingleThreadScheduledExecutor((r -> new Thread(r,"release"))));
-            DefaultPoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
+            PoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
                     Mono.fromCallable(PoolableTest::new)
                         .subscribeOn(Schedulers.newParallel("poolable test allocator")),
                     deliveryScheduler);
@@ -369,7 +364,7 @@ class SimpleLifoPoolTest {
                 AtomicReference<String> threadName = new AtomicReference<>();
                 AtomicInteger newCount = new AtomicInteger();
 
-                DefaultPoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
+                PoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
                         Mono.fromCallable(() -> new PoolableTest(newCount.getAndIncrement()))
                             .subscribeOn(allocatorScheduler),
                         deliveryScheduler);
@@ -458,7 +453,7 @@ class SimpleLifoPoolTest {
         void allocatedReleasedOrAbortedIfCancelRequestRace(int round, AtomicInteger newCount, AtomicInteger releasedCount, boolean cancelFirst) throws InterruptedException {
             Scheduler scheduler = Schedulers.newParallel("poolable test allocator");
 
-            DefaultPoolConfig<PoolableTest> testConfig = poolableTestConfig(0, 1,
+            PoolConfig<PoolableTest> testConfig = poolableTestConfig(0, 1,
                     Mono.defer(() -> Mono.delay(Duration.ofMillis(50)).thenReturn(new PoolableTest(newCount.incrementAndGet())))
                         .subscribeOn(scheduler),
                     pt -> releasedCount.incrementAndGet());
@@ -497,7 +492,7 @@ class SimpleLifoPoolTest {
         void defaultThreadDeliveringWhenHasElements() throws InterruptedException {
             AtomicReference<String> threadName = new AtomicReference<>();
             Scheduler acquireScheduler = Schedulers.newSingle("acquire");
-            DefaultPoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
+            PoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
                     Mono.fromCallable(PoolableTest::new)
                         .subscribeOn(Schedulers.newParallel("poolable test allocator")));
             SimpleLifoPool<PoolableTest> pool = new SimpleLifoPool<>(testConfig);
@@ -519,7 +514,7 @@ class SimpleLifoPoolTest {
         void defaultThreadDeliveringWhenNoElementsButNotFull() throws InterruptedException {
             AtomicReference<String> threadName = new AtomicReference<>();
             Scheduler acquireScheduler = Schedulers.newSingle("acquire");
-            DefaultPoolConfig<PoolableTest> testConfig = poolableTestConfig(0, 1,
+            PoolConfig<PoolableTest> testConfig = poolableTestConfig(0, 1,
                     Mono.fromCallable(PoolableTest::new)
                         .subscribeOn(Schedulers.newParallel("poolable test allocator")));
             SimpleLifoPool<PoolableTest> pool = new SimpleLifoPool<>(testConfig);
@@ -544,7 +539,7 @@ class SimpleLifoPoolTest {
             Scheduler acquireScheduler = Schedulers.newSingle("acquire");
             Scheduler releaseScheduler = Schedulers.fromExecutorService(
                     Executors.newSingleThreadScheduledExecutor((r -> new Thread(r,"release"))));
-            DefaultPoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
+            PoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
                     Mono.fromCallable(PoolableTest::new)
                         .subscribeOn(Schedulers.newParallel("poolable test allocator")));
             SimpleLifoPool<PoolableTest> pool = new SimpleLifoPool<>(testConfig);
@@ -576,7 +571,7 @@ class SimpleLifoPoolTest {
             Scheduler deliveryScheduler = Schedulers.newSingle("delivery");
             AtomicReference<String> threadName = new AtomicReference<>();
             Scheduler acquireScheduler = Schedulers.newSingle("acquire");
-            DefaultPoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
+            PoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
                     Mono.fromCallable(PoolableTest::new)
                         .subscribeOn(Schedulers.newParallel("poolable test allocator")),
                     deliveryScheduler);
@@ -600,7 +595,7 @@ class SimpleLifoPoolTest {
             Scheduler deliveryScheduler = Schedulers.newSingle("delivery");
             AtomicReference<String> threadName = new AtomicReference<>();
             Scheduler acquireScheduler = Schedulers.newSingle("acquire");
-            DefaultPoolConfig<PoolableTest> testConfig = poolableTestConfig(0, 1,
+            PoolConfig<PoolableTest> testConfig = poolableTestConfig(0, 1,
                     Mono.fromCallable(PoolableTest::new)
                         .subscribeOn(Schedulers.newParallel("poolable test allocator")),
                     deliveryScheduler);
@@ -627,7 +622,7 @@ class SimpleLifoPoolTest {
             Scheduler acquireScheduler = Schedulers.newSingle("acquire");
             Scheduler releaseScheduler = Schedulers.fromExecutorService(
                     Executors.newSingleThreadScheduledExecutor((r -> new Thread(r,"release"))));
-            DefaultPoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
+            PoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
                     Mono.fromCallable(PoolableTest::new)
                         .subscribeOn(Schedulers.newParallel("poolable test allocator")),
                     deliveryScheduler);
@@ -678,7 +673,7 @@ class SimpleLifoPoolTest {
                 AtomicInteger newCount = new AtomicInteger();
 
 
-                DefaultPoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
+                PoolConfig<PoolableTest> testConfig = poolableTestConfig(1, 1,
                         Mono.fromCallable(() -> new PoolableTest(newCount.getAndIncrement()))
                             .subscribeOn(allocatorScheduler),
                         deliveryScheduler);
@@ -731,7 +726,6 @@ class SimpleLifoPoolTest {
         AtomicInteger cleanerCount = new AtomicInteger();
         SimpleLifoPool<PoolableTest> pool = new SimpleLifoPool<>(
                 from(Mono.fromCallable(PoolableTest::new))
-                        .lifo(true)
                         .initialSize(3)
                         .sizeMax(3)
                         .releaseHandler(p -> Mono.fromRunnable(cleanerCount::incrementAndGet))


### PR DESCRIPTION
This commit heavily reworks how the PoolBuilder is producing a PoolConfig
(internally) and then a concrete Pool instance.

The goal is to open the builder for cases where implementations would be
provided by external projects (eg. a netty event-loop aware implementation
for a project that pools netty connections).

One can pass a factory Function to the builder to create such a custom
pool, possibly also switching the builder to a custom type of configuration
beforehand. As a result, the DefaultPoolConfig has now been extracted as
PoolConfig and made public.

As a shorthand for the `build(Function)` that produces reactor-pool vanilla
implementations, we now expose `lifo()` and
`fifo()`, which are now the two out-of-the-box provided flavors.