### PR TITLE
fix #53 Remove initSize, add permitMinimum and do warmup on acquire

### DIFF
--- a/src/main/java/reactor/pool/AllocationStrategies.java
+++ b/src/main/java/reactor/pool/AllocationStrategies.java
@@ -88,7 +88,7 @@ final class AllocationStrategies {
 
         @Override
         public int getPermits(int desired) {
-            if (desired < 1) return 0;
+            if (desired < 0) return 0;
 
             //impl note: this should be more efficient compared to the previous approach for desired == 1
             // (incrementAndGet + decrementAndGet compensation both induce a CAS loop, vs single loop here)

--- a/src/main/java/reactor/pool/AllocationStrategies.java
+++ b/src/main/java/reactor/pool/AllocationStrategies.java
@@ -54,6 +54,11 @@ final class AllocationStrategies {
         }
 
         @Override
+        public int permitMinimum() {
+            return 0;
+        }
+
+        @Override
         public int permitMaximum() {
             return Integer.MAX_VALUE;
         }
@@ -66,14 +71,18 @@ final class AllocationStrategies {
 
     static final class SizeBasedAllocationStrategy implements AllocationStrategy {
 
+        final int min;
         final int max;
 
         volatile int permits;
         static final AtomicIntegerFieldUpdater<SizeBasedAllocationStrategy> PERMITS = AtomicIntegerFieldUpdater.newUpdater(SizeBasedAllocationStrategy.class, "permits");
 
-        SizeBasedAllocationStrategy(int max) {
+        SizeBasedAllocationStrategy(int min, int max) {
+            if (min < 0) throw new IllegalArgumentException("min must be positive or zero");
             if (max < 1) throw new IllegalArgumentException("max must be strictly positive");
-            this.max = Math.max(1, max);
+            if (min > max) throw new IllegalArgumentException("min must be less than or equal to max");
+            this.min = min;
+            this.max = max;
             PERMITS.lazySet(this, this.max);
         }
 
@@ -84,11 +93,22 @@ final class AllocationStrategies {
             //impl note: this should be more efficient compared to the previous approach for desired == 1
             // (incrementAndGet + decrementAndGet compensation both induce a CAS loop, vs single loop here)
             for (;;) {
+                int target;
                 int p = permits;
-                int possible = Math.min(desired, p);
+                int granted = max - p;
 
-                if (PERMITS.compareAndSet(this, p, p - possible)) {
-                    return possible;
+                if (desired >= p) {
+                    target = p;
+                }
+                else if (granted < min) {
+                    target = Math.max(desired, min - granted);
+                }
+                else {
+                    target = desired;
+                }
+
+                if (PERMITS.compareAndSet(this, p, p - target)) {
+                    return target;
                 }
             }
         }
@@ -96,6 +116,11 @@ final class AllocationStrategies {
         @Override
         public int estimatePermitCount() {
             return PERMITS.get(this);
+        }
+
+        @Override
+        public int permitMinimum() {
+            return min;
         }
 
         @Override

--- a/src/main/java/reactor/pool/AllocationStrategies.java
+++ b/src/main/java/reactor/pool/AllocationStrategies.java
@@ -72,6 +72,7 @@ final class AllocationStrategies {
         static final AtomicIntegerFieldUpdater<SizeBasedAllocationStrategy> PERMITS = AtomicIntegerFieldUpdater.newUpdater(SizeBasedAllocationStrategy.class, "permits");
 
         SizeBasedAllocationStrategy(int max) {
+            if (max < 1) throw new IllegalArgumentException("max must be strictly positive");
             this.max = Math.max(1, max);
             PERMITS.lazySet(this, this.max);
         }

--- a/src/main/java/reactor/pool/AllocationStrategy.java
+++ b/src/main/java/reactor/pool/AllocationStrategy.java
@@ -36,8 +36,11 @@ public interface AllocationStrategy {
      * Try to get the permission to allocate a {@code desired} positive number of new resources. Returns the permissible
      * number of resources which MUST be created (otherwise the internal live counter of the strategy might be off).
      * This permissible number might be zero, and it can also be a greater number than {@code desired}, which could for
-     * example denote a minimum warmed-up size for the pool to maintain. Once a resource is discarded from the pool, it must
-     * update the strategy using {@link #returnPermits(int)} (which can happen in batches or with value {@literal 1}).
+     * example denote a minimum warmed-up size for the pool to maintain (see below).
+     * Once a resource is discarded from the pool, it must update the strategy using {@link #returnPermits(int)}
+     * (which can happen in batches or with value {@literal 1}).
+     * <p>
+     * For the warming up case, the typical pattern would be to call this method with a {@code desired} of zero.
      *
      * @param desired the desired number of new resources
      * @return the actual number of new resources that MUST be created, can be 0 and can be more than {@code desired}

--- a/src/main/java/reactor/pool/AllocationStrategy.java
+++ b/src/main/java/reactor/pool/AllocationStrategy.java
@@ -35,11 +35,12 @@ public interface AllocationStrategy {
     /**
      * Try to get the permission to allocate a {@code desired} positive number of new resources. Returns the permissible
      * number of resources which MUST be created (otherwise the internal live counter of the strategy might be off).
-     * This permissible number might be zero. Once a resource is discarded from the pool, it must
+     * This permissible number might be zero, and it can also be a greater number than {@code desired}, which could for
+     * example denote a minimum warmed-up size for the pool to maintain. Once a resource is discarded from the pool, it must
      * update the strategy using {@link #returnPermits(int)} (which can happen in batches or with value {@literal 1}).
      *
      * @param desired the desired number of new resources
-     * @return the acceptable number of new resources, might be zero
+     * @return the actual number of new resources that MUST be created, can be 0 and can be more than {@code desired}
      */
     int getPermits(int desired);
 
@@ -47,6 +48,14 @@ public interface AllocationStrategy {
      * @return a best estimate of the number of permits currently granted, between 0 and {@link Integer#MAX_VALUE}
      */
     int permitGranted();
+
+    /**
+     * Return the minimum number of permits this strategy tries to maintain granted
+     * (reflecting a minimal size for the pool), or {@code 0} for scale-to-zero.
+     *
+     * @return the minimum number of permits this strategy tries to maintain, or {@code 0}
+     */
+    int permitMinimum();
 
     /**
      * @return the maximum number of permits this strategy can grant in total, or {@link Integer#MAX_VALUE} for unbounded.

--- a/src/main/java/reactor/pool/DefaultPoolConfig.java
+++ b/src/main/java/reactor/pool/DefaultPoolConfig.java
@@ -33,7 +33,6 @@ import reactor.core.scheduler.Scheduler;
 public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 
 	protected final Mono<POOLABLE>                                allocator;
-	protected final int                                           initialSize;
 	protected final AllocationStrategy                            allocationStrategy;
 	protected final int                                           maxPending;
 	protected final Function<POOLABLE, ? extends Publisher<Void>> releaseHandler;
@@ -43,7 +42,6 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 	protected final PoolMetricsRecorder                           metricsRecorder;
 
 	public DefaultPoolConfig(Mono<POOLABLE> allocator,
-			int initialSize,
 			AllocationStrategy allocationStrategy,
 			int maxPending,
 			Function<POOLABLE, ? extends Publisher<Void>> releaseHandler,
@@ -52,7 +50,6 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 			Scheduler acquisitionScheduler,
 			PoolMetricsRecorder metricsRecorder) {
 		this.allocator = allocator;
-		this.initialSize = initialSize;
 		this.allocationStrategy = allocationStrategy;
 		this.maxPending = maxPending;
 		this.releaseHandler = releaseHandler;
@@ -72,7 +69,6 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 		if (toCopy instanceof DefaultPoolConfig) {
 			DefaultPoolConfig<POOLABLE> toCopyDpc = (DefaultPoolConfig<POOLABLE>) toCopy;
 			this.allocator = toCopyDpc.allocator;
-			this.initialSize = toCopyDpc.initialSize;
 			this.allocationStrategy = toCopyDpc.allocationStrategy;
 			this.maxPending = toCopyDpc.maxPending;
 			this.releaseHandler = toCopyDpc.releaseHandler;
@@ -83,7 +79,6 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 		}
 		else {
 			this.allocator = toCopy.allocator();
-			this.initialSize = toCopy.initialSize();
 			this.allocationStrategy = toCopy.allocationStrategy();
 			this.maxPending = toCopy.maxPending();
 			this.releaseHandler = toCopy.releaseHandler();
@@ -97,11 +92,6 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 	@Override
 	public Mono<POOLABLE> allocator() {
 		return this.allocator;
-	}
-
-	@Override
-	public int initialSize() {
-		return this.initialSize;
 	}
 
 	@Override

--- a/src/main/java/reactor/pool/Pool.java
+++ b/src/main/java/reactor/pool/Pool.java
@@ -15,14 +15,14 @@
  */
 package reactor.pool;
 
+import java.time.Duration;
+import java.util.function.Function;
+
 import org.reactivestreams.Publisher;
+
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
-import java.time.Duration;
-import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * A reactive pool of objects.
@@ -85,7 +85,7 @@ public interface Pool<POOLABLE> extends Disposable {
      */
     Mono<PooledRef<POOLABLE>> acquire(Duration timeout);
 
-    /**
+	/**
      * Acquire a {@code POOLABLE} object from the pool upon subscription and declaratively use it, automatically releasing
      * the object back to the pool once the derived usage pipeline terminates or is cancelled. This acquire-use-and-release
      * scope is represented by a user provided {@link Function}.

--- a/src/main/java/reactor/pool/PoolConfig.java
+++ b/src/main/java/reactor/pool/PoolConfig.java
@@ -39,11 +39,6 @@ public interface PoolConfig<POOLABLE> {
 	Mono<POOLABLE> allocator();
 
 	/**
-	 * The minimum number of objects a {@link Pool} should create at initialization.
-	 */
-	int initialSize();
-
-	/**
 	 * {@link AllocationStrategy} defines a strategy / limit for the number of pooled object to allocate.
 	 */
 	AllocationStrategy allocationStrategy();

--- a/src/main/java/reactor/pool/SimplePool.java
+++ b/src/main/java/reactor/pool/SimplePool.java
@@ -68,7 +68,7 @@ abstract class SimplePool<POOLABLE> extends AbstractPool<POOLABLE> {
         if (poolConfig.allocationStrategy().permitMinimum() > 0) {
             //TODO remove that from constructor (eg. warmup method)?
             //TODO modify tests accordingly
-            int initSize = poolConfig.allocationStrategy().getPermits(1);
+            int initSize = poolConfig.allocationStrategy().getPermits(0);
             for (int i = 0; i < initSize; i++) {
                 long start = metricsRecorder.now();
                 try {

--- a/src/main/java/reactor/pool/SimplePool.java
+++ b/src/main/java/reactor/pool/SimplePool.java
@@ -66,38 +66,38 @@ abstract class SimplePool<POOLABLE> extends AbstractPool<POOLABLE> {
         super(poolConfig, Loggers.getLogger(SimplePool.class));
         this.elements = Queues.<QueuePooledRef<POOLABLE>>unboundedMultiproducer().get();
 
-		//TODO remove that from constructor (eg. warmup official API)?
-	    //TODO modify tests accordingly
-	    warmup().block();
+        //TODO remove that from constructor (eg. warmup official API)?
+        //TODO modify tests accordingly
+        warmup().block();
     }
 
-	private Mono<Integer> warmup() {
-		if (poolConfig.allocationStrategy().permitMinimum() > 0) {
-			return Mono.defer(() -> {
-				int initSize = poolConfig.allocationStrategy().getPermits(0);
-				@SuppressWarnings("unchecked")
-				Mono<POOLABLE>[] allWarmups = new Mono[initSize];
-				for (int i = 0; i < initSize; i++) {
-					long start = metricsRecorder.now();
-					allWarmups[i] = poolConfig
-							.allocator()
-							.doOnNext(p -> {
-								metricsRecorder.recordAllocationSuccessAndLatency(metricsRecorder.measureTime(start));
-								elements.offer(new QueuePooledRef<>(this, p)); //the pool slot won't access this pool instance until after it has been constructed
-							})
-							.doOnError(e -> {
-								metricsRecorder.recordAllocationFailureAndLatency(metricsRecorder.measureTime(start));
-								poolConfig.allocationStrategy().returnPermits(1);
-							});
-				}
-				return Flux.concat(allWarmups)
-				           .reduce(0, (count, p) -> count + 1);
-			});
-		}
-		else {
-			return Mono.just(0);
-		}
-	}
+    private Mono<Integer> warmup() {
+        if (poolConfig.allocationStrategy().permitMinimum() > 0) {
+            return Mono.defer(() -> {
+                int initSize = poolConfig.allocationStrategy().getPermits(0);
+                @SuppressWarnings("unchecked") Mono<POOLABLE>[] allWarmups = new Mono[initSize];
+                for (int i = 0; i < initSize; i++) {
+                    long start = metricsRecorder.now();
+                    allWarmups[i] = poolConfig
+                            .allocator()
+                            .doOnNext(p -> {
+                                metricsRecorder.recordAllocationSuccessAndLatency(metricsRecorder.measureTime(start));
+                                //the pool slot won't access this pool instance until after it has been constructed
+                                elements.offer(new QueuePooledRef<>(this, p));
+                            })
+                            .doOnError(e -> {
+                                metricsRecorder.recordAllocationFailureAndLatency(metricsRecorder.measureTime(start));
+                                poolConfig.allocationStrategy().returnPermits(1);
+                            });
+                }
+                return Flux.concat(allWarmups)
+                           .reduce(0, (count, p) -> count + 1);
+            });
+        }
+        else {
+            return Mono.just(0);
+        }
+    }
 
     /**
      * @return the next {@link reactor.pool.AbstractPool.Borrower} to serve

--- a/src/test/java/reactor/pool/AllocationStrategiesTest.java
+++ b/src/test/java/reactor/pool/AllocationStrategiesTest.java
@@ -44,42 +44,63 @@ class AllocationStrategiesTest {
 
     private static final Logger LOG = Loggers.getLogger(AllocationStrategies.class);
 
-    @DisplayName("allocatingMax")
+    @DisplayName("allocatingSize")
     @Nested
-    class AllocatingMaxTest {
+    class AllocatingSizeTest {
 
         @Test
         void negativeMaxThrows() {
             assertThatIllegalArgumentException()
-                    .isThrownBy(() -> new SizeBasedAllocationStrategy(-1))
+                    .isThrownBy(() -> new SizeBasedAllocationStrategy(0, -1))
                     .withMessage("max must be strictly positive");
         }
 
         @Test
         void zeroMaxThrows() {
             assertThatIllegalArgumentException()
-                    .isThrownBy(() -> new SizeBasedAllocationStrategy(0))
+                    .isThrownBy(() -> new SizeBasedAllocationStrategy(0, 0))
                     .withMessage("max must be strictly positive");
         }
 
         @Test
-        void onePermitCount() {
-            AllocationStrategy test = new SizeBasedAllocationStrategy(1);
+        void negativeMinThrows() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new SizeBasedAllocationStrategy(-1, 0))
+                    .withMessage("min must be positive or zero");
+        }
+
+        @Test
+        void minMoreThanMaxThrows() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new SizeBasedAllocationStrategy(2, 1))
+                    .withMessage("min must be less than or equal to max");
+        }
+
+        @Test
+        void minDoesntInfluenceInitialPermitCount() {
+            AllocationStrategy test = new SizeBasedAllocationStrategy(2, 5);
+
+            assertThat(test.estimatePermitCount()).isEqualTo(5);
+        }
+
+        @Test
+        void atMostOnePermitCount() {
+            AllocationStrategy test = new SizeBasedAllocationStrategy(0, 1);
 
             assertThat(test.estimatePermitCount()).isOne();
         }
 
         @Test
-        void onePermitGet() {
-            AllocationStrategy test = new SizeBasedAllocationStrategy(1);
+        void atMostOnePermitGet() {
+            AllocationStrategy test = new SizeBasedAllocationStrategy(0, 1);
 
             assertThat(test.getPermits(1)).as("first try").isOne();
             assertThat(test.getPermits(1)).as("second try").isZero();
         }
 
         @Test
-        void onePermitGetDesired() {
-            AllocationStrategy test = new SizeBasedAllocationStrategy(1);
+        void atMostOnePermitGetDesired() {
+            AllocationStrategy test = new SizeBasedAllocationStrategy(0, 1);
 
             assertThat(test.getPermits(100)).as("desired 100").isOne();
             assertThat(test.getPermits(1)).as("desired 1 more").isZero();
@@ -87,41 +108,106 @@ class AllocationStrategiesTest {
 
         @Test
         void getPermitDesiredZero() {
-            AllocationStrategy test = new SizeBasedAllocationStrategy(1);
+            AllocationStrategy test = new SizeBasedAllocationStrategy(0, 1);
+
+            assertThat(test.getPermits(0)).isZero();
+        }
+
+        @Test
+        void getPermitDesiredZeroDespiteMin() {
+            AllocationStrategy test = new SizeBasedAllocationStrategy(1, 2);
 
             assertThat(test.getPermits(0)).isZero();
         }
 
         @Test
         void getPermitDesiredNegative() {
-            AllocationStrategy test = new SizeBasedAllocationStrategy(1);
+            AllocationStrategy test = new SizeBasedAllocationStrategy(1, 2);
 
             assertThat(test.getPermits(-1)).isZero();
         }
 
+        //TODO should we be more strict in enforcing max here?
         @Test
-        void returnPermitCanGoOverMax() {
-            final AllocationStrategy test = new SizeBasedAllocationStrategy(1);
+        void misuseReturnPermitCanGoOverMax() {
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(0, 1);
 
             test.returnPermits(1);
 
             assertThat(test.estimatePermitCount()).isEqualTo(2);
         }
 
+        //TODO should we be more strict in enforcing max here?
         @Test
-        void returnPermitsCanGoOverMax() {
-            final AllocationStrategy test = new SizeBasedAllocationStrategy(1);
+        void misuseReturnPermitsCanGoOverMax() {
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(0, 1);
 
             test.returnPermits(100);
 
             assertThat(test.estimatePermitCount()).isEqualTo(101);
         }
 
+        @Test
+        void minMaxPermitScenario1() {
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(2, 3);
+
+            assertThat(test.estimatePermitCount()).as("initial state").isEqualTo(3);
+
+            assertThat(test.getPermits(1)).as("granted for get(1)").isEqualTo(2);
+            assertThat(test.estimatePermitCount()).as("after get").isOne();
+
+            assertThat(test.getPermits(2)).as("granted for get(2)").isOne();
+            assertThat(test.estimatePermitCount()).as("after second get").isZero();
+
+            assertThat(test.getPermits(1)).as("get when max reached").isZero();
+            assertThat(test.estimatePermitCount()).as("after no-op get").isZero();
+        }
+
+        @Test
+        void minMaxPermitScenario2() {
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(4, 8);
+
+            int firstGet = test.getPermits(1);
+            test.returnPermits(1);
+            test.returnPermits(2);
+            int secondGet = test.getPermits(1);
+            int drainingGet = test.getPermits(4);
+            int starvedGet = test.getPermits(1);
+
+            assertThat(firstGet).as("first getPermits(1)").isEqualTo(4);
+            assertThat(secondGet).as("second getPermits(1)").isEqualTo(3);
+            assertThat(drainingGet).as("draining getPermits(4)").isEqualTo(4);
+            assertThat(starvedGet).as("starved getPermits(1)").isZero();
+        }
+
+        @Test
+        void minMaxPermitWhenPartiallyStarved() {
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(4, 8);
+            test.getPermits(6);
+
+            assertThat(test.getPermits(4)).isEqualTo(2);
+        }
+
+        @Test
+        void minMaxPermitWhenTotallyStarved() {
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(4, 8);
+            test.getPermits(8);
+
+            assertThat(test.getPermits(4)).isZero();
+        }
+
+        @Test
+        void minMaxPermitWhenDesiredGreaterThanMin() {
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(4, 8);
+
+            assertThat(test.getPermits(5)).isEqualTo(5);
+        }
+
         @ParameterizedTest(name = "{0} workers")
         @ValueSource(ints = {5, 10, 20})
         @Tag("race")
         void raceGetPermit(int workerCount) throws InterruptedException {
-            final AllocationStrategy test = new SizeBasedAllocationStrategy(10);
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(0, 10);
 
             LongAdder counter = new LongAdder();
             ExecutorService es = Executors.newFixedThreadPool(workerCount);
@@ -146,7 +232,7 @@ class AllocationStrategiesTest {
         @ValueSource(ints = {5, 10, 20})
         @Tag("race")
         void racePermitsRandom(int workerCount, TestInfo testInfo) throws InterruptedException {
-            final AllocationStrategy test = new SizeBasedAllocationStrategy(10);
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(0, 10);
 
             LongAdder counter = new LongAdder();
             LongAdder gotZeroCounter = new LongAdder();
@@ -177,7 +263,7 @@ class AllocationStrategiesTest {
         @ValueSource(ints = {5, 10, 20})
         @Tag("race")
         void raceMixGetPermitWithGetRandomPermits(int workerCount, TestInfo testInfo) throws InterruptedException {
-            final AllocationStrategy test = new SizeBasedAllocationStrategy(10);
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(0, 10);
 
             LongAdder usedGetRandomPermits = new LongAdder();
             LongAdder usedGetPermit = new LongAdder();
@@ -223,7 +309,7 @@ class AllocationStrategiesTest {
         @ValueSource(ints = {5, 10, 20})
         @Tag("race")
         void racePermitsRandomWithInnerLoop(int workerCount, TestInfo testInfo) throws InterruptedException {
-            final AllocationStrategy test = new SizeBasedAllocationStrategy(10);
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(0, 10);
 
             LongAdder counter = new LongAdder();
             LongAdder gotZeroCounter = new LongAdder();
@@ -250,6 +336,8 @@ class AllocationStrategiesTest {
             assertThat(counter.sum()).as("permits acquired").isBetween(1_000_000L, 10_000_000L);
             assertThat(test.estimatePermitCount()).as("end permit count").isEqualTo(10);
         }
+
+        //TODO race tests with a minimum
     }
 
     @DisplayName("unbounded")

--- a/src/test/java/reactor/pool/AllocationStrategiesTest.java
+++ b/src/test/java/reactor/pool/AllocationStrategiesTest.java
@@ -35,6 +35,7 @@ import reactor.util.Logger;
 import reactor.util.Loggers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
  * @author Simon Baslé
@@ -48,17 +49,17 @@ class AllocationStrategiesTest {
     class AllocatingMaxTest {
 
         @Test
-        void negativeMaxGivesOnePermit() {
-            AllocationStrategy test = new SizeBasedAllocationStrategy(-1);
-
-            assertThat(test.estimatePermitCount()).isOne();
+        void negativeMaxThrows() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new SizeBasedAllocationStrategy(-1))
+                    .withMessage("max must be strictly positive");
         }
 
         @Test
-        void zeroMaxGivesOnePermit() {
-            AllocationStrategy test = new SizeBasedAllocationStrategy(0);
-
-            assertThat(test.estimatePermitCount()).isOne();
+        void zeroMaxThrows() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new SizeBasedAllocationStrategy(0))
+                    .withMessage("max must be strictly positive");
         }
 
         @Test

--- a/src/test/java/reactor/pool/AllocationStrategiesTest.java
+++ b/src/test/java/reactor/pool/AllocationStrategiesTest.java
@@ -107,17 +107,28 @@ class AllocationStrategiesTest {
         }
 
         @Test
-        void getPermitDesiredZero() {
+        void getPermitDesiredZeroWithNoMin() {
             AllocationStrategy test = new SizeBasedAllocationStrategy(0, 1);
 
             assertThat(test.getPermits(0)).isZero();
         }
 
         @Test
-        void getPermitDesiredZeroDespiteMin() {
-            AllocationStrategy test = new SizeBasedAllocationStrategy(1, 2);
+        void getPermitDesiredZeroWithMin() {
+            AllocationStrategy test = new SizeBasedAllocationStrategy(4, 8);
 
-            assertThat(test.getPermits(0)).isZero();
+            assertThat(test.getPermits(0)).isEqualTo(4);
+        }
+
+        @Test
+        void getPermitDesiredZeroWithMinPartiallyReached() {
+            AllocationStrategy test = new SizeBasedAllocationStrategy(4, 8);
+            //first getPermit returns min, but we can return some of these permits
+            assertThat(test.getPermits(0)).as("initial warmup").isEqualTo(4);
+
+            test.returnPermits(3);
+
+            assertThat(test.getPermits(0)).as("partial warmup").isEqualTo(3);
         }
 
         @Test

--- a/src/test/java/reactor/pool/CommonPoolTest.java
+++ b/src/test/java/reactor/pool/CommonPoolTest.java
@@ -114,8 +114,7 @@ public class CommonPoolTest {
 		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				//default maxUse is 5, but this test relies on it being 2
 				.from(Mono.defer(() -> Mono.just(new PoolableTest(newCount.incrementAndGet(), 2))))
-				.initialSize(2)
-				.sizeMax(3)
+				.sizeBetween(2, 3)
 				.releaseHandler(pt -> Mono.fromRunnable(pt::clean))
 				.evictionPredicate((poolable, metadata) -> !poolable.isHealthy());
 
@@ -169,8 +168,7 @@ public class CommonPoolTest {
 		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				//default maxUse is 5, but this test relies on it being 2
 				.from(Mono.defer(() -> Mono.just(new PoolableTest(newCount.incrementAndGet(), 2))))
-				.initialSize(2)
-				.sizeMax(3)
+				.sizeBetween(2, 3)
 				.releaseHandler(pt -> Mono.fromRunnable(pt::clean))
 				.evictionPredicate((poolable, metadata) -> !poolable.isHealthy());
 		Pool<PoolableTest> pool = configAdjuster.apply(builder);
@@ -233,8 +231,7 @@ public class CommonPoolTest {
 				//default maxUse is 5, but this test relies on it being 2
 				.from(Mono.defer(() -> Mono.just(new PoolableTest(newCount.incrementAndGet(), 2)))
 				          .subscribeOn(Schedulers.newParallel("poolable test allocator")))
-				.initialSize(2)
-				.sizeMax(3)
+				.sizeBetween(2, 3)
 				.releaseHandler(pt -> Mono.fromRunnable(pt::clean))
 				.evictionPredicate((poolable, metadata) -> !poolable.isHealthy());
 
@@ -346,8 +343,7 @@ public class CommonPoolTest {
 		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				//default maxUse is 5, but this test relies on it being 2
 				.from(Mono.defer(() -> Mono.just(new PoolableTest(newCount.incrementAndGet(), 2))))
-				.initialSize(2)
-				.sizeMax(3)
+				.sizeBetween(2, 3)
 				.releaseHandler(pt -> Mono.fromRunnable(pt::clean))
 				.evictionPredicate((value, metadata) -> !value.isHealthy());
 		AbstractPool<PoolableTest> pool = configAdjuster.apply(builder);
@@ -399,8 +395,7 @@ public class CommonPoolTest {
 		PoolBuilder<PoolableTest, ?> builder =
 				//default maxUse is 5, but this test relies on it being 2
 				PoolBuilder.from(Mono.defer(() -> Mono.just(new PoolableTest(newCount.incrementAndGet(), 2))))
-				           .initialSize(2)
-				           .sizeMax(3)
+				           .sizeBetween(2, 3)
 				           .releaseHandler(pt -> Mono.fromRunnable(pt::clean))
 				           .evictionPredicate((value, metadata) -> !value.isHealthy());
 		AbstractPool<PoolableTest> pool = configAdjuster.apply(builder);
@@ -466,8 +461,7 @@ public class CommonPoolTest {
 				.from(Mono.defer(() -> Mono.just(new PoolableTest(newCount.incrementAndGet(), 2)))
 				          .subscribeOn(Schedulers.newParallel(
 						          "poolable test allocator")))
-				.initialSize(2)
-				.sizeMax(3)
+				.sizeBetween(2, 3)
 				.releaseHandler(pt -> Mono.fromRunnable(pt::clean))
 				.evictionPredicate((value, metadata) -> !value.isHealthy());
 		AbstractPool<PoolableTest> pool = configAdjuster.apply(builder);
@@ -533,13 +527,94 @@ public class CommonPoolTest {
 
 	@ParameterizedTest
 	@MethodSource("allPools")
+	void firstAcquireCausesWarmupWithMinSize(Function<PoolBuilder<PoolableTest, ?>, Pool<PoolableTest>> configAdjuster)
+			throws InterruptedException {
+		AtomicInteger allocationCount = new AtomicInteger();
+
+		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
+				.from(Mono.fromCallable(() -> {
+					int id = allocationCount.incrementAndGet();
+					return new PoolableTest(id);
+				}))
+				.sizeBetween(4, 8)
+				.releaseHandler(p -> Mono.fromRunnable(p::clean));
+
+		final Pool<PoolableTest> pool = configAdjuster.apply(builder);
+		assertThat(pool).isInstanceOf(InstrumentedPool.class);
+
+		final PoolMetrics metrics = ((InstrumentedPool) pool).metrics();
+
+		assertThat(metrics.allocatedSize()).as("ctor allocated").isZero();
+
+		final PooledRef<PoolableTest> firstAcquire = pool.acquire()
+		                                                 .block();
+
+		assertThat(metrics.allocatedSize()).as("warmup allocated").isEqualTo(4);
+		assertThat(metrics.idleSize()).as("warmup idle").isEqualTo(3);
+
+		final PooledRef<PoolableTest> secondAcquire = pool.acquire()
+		                                                  .block();
+
+		assertThat(metrics.allocatedSize()).as("second acquire allocated").isEqualTo(4);
+		assertThat(metrics.idleSize()).as("second acquire idle").isEqualTo(2);
+
+		//give time for an unexpected warmup to take place so that the last assertion is valid
+		Thread.sleep(100);
+		assertThat(allocationCount).as("total allocations").hasValue(4);
+	}
+
+	@ParameterizedTest
+	@MethodSource("allPools")
+	void releaseBelowMinSizeThreshold(Function<PoolBuilder<PoolableTest, ?>, Pool<PoolableTest>> configAdjuster)
+			throws InterruptedException {
+		AtomicInteger allocationCount = new AtomicInteger();
+
+		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
+				.from(Mono.fromCallable(() -> {
+					int id = allocationCount.incrementAndGet();
+					return new PoolableTest(id);
+				}))
+				.sizeBetween(3, 4)
+				.releaseHandler(p -> Mono.fromRunnable(p::clean));
+
+		final Pool<PoolableTest> pool = configAdjuster.apply(builder);
+		assertThat(pool).isInstanceOf(InstrumentedPool.class);
+		final PoolMetrics metrics = ((InstrumentedPool) pool).metrics();
+
+		final PooledRef<PoolableTest> ref1 = pool.acquire().block();
+		final PooledRef<PoolableTest> ref2 = pool.acquire().block();
+		final PooledRef<PoolableTest> ref3 = pool.acquire().block();
+		final PooledRef<PoolableTest> ref4 = pool.acquire().block();
+
+		assertThat(metrics.allocatedSize()).as("initial allocated").isEqualTo(4);
+		assertThat(metrics.idleSize()).as("initial idle").isEqualTo(0);
+
+		ref1.invalidate().block();
+		ref2.invalidate().block();
+		ref3.invalidate().block();
+
+		assertThat(metrics.allocatedSize()).as("3 releases: allocated").isEqualTo(1);
+		assertThat(metrics.idleSize()).as("3 releases: idle").isEqualTo(0);
+
+		PooledRef<PoolableTest> ref5 = pool.acquire()
+		                                   .block();
+
+		assertThat(metrics.allocatedSize()).as("second acquire allocated").isEqualTo(3); //1 borrowed, 1 acquiring, 1 extra matches min of 3
+		assertThat(metrics.idleSize()).as("second acquire idle").isEqualTo(1); //only 1 extra created this time
+
+		//give time for an unexpected warmup to take place so that the last assertion is valid
+		Thread.sleep(100);
+		assertThat(allocationCount).as("total allocations").hasValue(6);
+	}
+
+	@ParameterizedTest
+	@MethodSource("allPools")
 	void returnedNotReleasedIfBorrowerCancelledEarly(Function<PoolBuilder<PoolableTest, ?>, Pool<PoolableTest>> configAdjuster) {
 		AtomicInteger releasedCount = new AtomicInteger();
 
 		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(PoolableTest::new))
-				.initialSize(1)
-				.sizeMax(1)
+				.sizeBetween(1, 1)
 				.releaseHandler(poolableTest -> Mono.fromRunnable(() -> {
 					poolableTest.clean();
 					releasedCount.incrementAndGet();
@@ -570,8 +645,7 @@ public class CommonPoolTest {
 
 		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(PoolableTest::new))
-				.initialSize(1)
-				.sizeMax(1)
+				.sizeBetween(1, 1)
 				.destroyHandler(poolableTest -> Mono.fromRunnable(() -> {
 					poolableTest.clean();
 					releasedCount.incrementAndGet();
@@ -616,8 +690,7 @@ public class CommonPoolTest {
 		AtomicInteger releasedCount = new AtomicInteger();
 		PoolBuilder<PoolableTest, ?> builder =
 				PoolBuilder.from(Mono.fromCallable(PoolableTest::new))
-				           .initialSize(1)
-				           .sizeMax(1)
+				           .sizeBetween(1, 1)
 				           .releaseHandler(poolableTest -> Mono.fromRunnable(() -> {
 					           poolableTest.clean();
 					           releasedCount.incrementAndGet();
@@ -683,7 +756,6 @@ public class CommonPoolTest {
 		PoolBuilder<PoolableTest, ?> builder =
 				PoolBuilder.from(Mono.defer(() -> Mono.delay(Duration.ofMillis(50)).thenReturn(new PoolableTest(newCount.incrementAndGet())))
 				                     .subscribeOn(scheduler))
-				           .initialSize(0)
 				           .sizeMax(1)
 				           .releaseHandler(poolableTest -> Mono.fromRunnable(() -> {
 					           poolableTest.clean();
@@ -713,9 +785,8 @@ public class CommonPoolTest {
 
 		try {
 			PoolBuilder<Integer, ?> builder = PoolBuilder.from(Mono.fromCallable(allocatorCount::incrementAndGet))
-			                                          .sizeMax(1)
-			                                          .initialSize(1)
-			                                          .maxPendingAcquire(1);
+			                                             .sizeBetween(1, 1)
+			                                             .maxPendingAcquire(1);
 			AbstractPool<Integer> pool = configAdjuster.apply(builder);
 			PooledRef<Integer> hold = pool.acquire().block();
 
@@ -761,9 +832,8 @@ public class CommonPoolTest {
 
 		try {
 			PoolBuilder<Integer, ?> builder = PoolBuilder.from(Mono.fromCallable(allocatorCount::incrementAndGet))
-			                                          .sizeMax(1)
-			                                          .initialSize(1)
-			                                          .maxPendingAcquire(1);
+			                                             .sizeBetween(1, 1)
+			                                             .maxPendingAcquire(1);
 			AbstractPool<Integer> pool = configAdjuster.apply(builder);
 			PooledRef<Integer> hold = pool.acquire().block();
 
@@ -883,8 +953,7 @@ public class CommonPoolTest {
 		AtomicInteger cleanerCount = new AtomicInteger();
 		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(PoolableTest::new))
-				.sizeMax(3)
-				.initialSize(3)
+				.sizeBetween(3, 3)
 				.releaseHandler(p -> Mono.fromRunnable(cleanerCount::incrementAndGet))
 				.evictionPredicate((poolable, metadata) -> !poolable.isHealthy());
 
@@ -923,8 +992,7 @@ public class CommonPoolTest {
 		AtomicInteger cleanerCount = new AtomicInteger();
 		PoolBuilder<PoolableTest, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(PoolableTest::new))
-				.sizeMax(3)
-				.initialSize(3)
+				.sizeBetween(3, 3)
 				.releaseHandler(p -> Mono.fromRunnable(cleanerCount::incrementAndGet))
 				.evictionPredicate((poolable, metadata) -> !poolable.isHealthy());
 		AbstractPool<PoolableTest> pool = configAdjuster.apply(builder);
@@ -995,8 +1063,7 @@ public class CommonPoolTest {
 
 		PoolBuilder<Formatter, ?> builder = PoolBuilder
 				.from(Mono.just(uniqueElement))
-				.sizeMax(1)
-				.initialSize(1)
+				.sizeBetween(1, 1)
 				.evictionPredicate((poolable, metadata) -> true);
 		AbstractPool<Formatter> pool = configAdjuster.apply(builder);
 
@@ -1013,8 +1080,7 @@ public class CommonPoolTest {
 
 		PoolBuilder<Formatter, ?> builder = PoolBuilder
 				.from(Mono.just(uniqueElement))
-				.sizeMax(1)
-				.initialSize(1)
+				.sizeBetween(1, 1)
 				.evictionPredicate((poolable, metadata) -> true);
 		AbstractPool<Formatter> pool = configAdjuster.apply(builder);
 
@@ -1036,8 +1102,7 @@ public class CommonPoolTest {
 
 		PoolBuilder<AtomicBoolean, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(() -> elements.get(index.getAndIncrement())))
-				.sizeMax(3)
-				.initialSize(3)
+				.sizeBetween(3, 3)
 				.evictionPredicate((poolable, metadata) -> true)
 				.destroyHandler(ab -> Mono.fromRunnable(() -> ab.set(true)));
 		AbstractPool<AtomicBoolean> pool = configAdjuster.apply(builder);
@@ -1058,8 +1123,7 @@ public class CommonPoolTest {
 
 		PoolBuilder<Integer, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(live::getAndIncrement))
-				.sizeMax(3)
-				.initialSize(3)
+				.sizeBetween(3, 3)
 				.evictionPredicate((poolable, metadata) -> true)
 				.destroyHandler(ab -> Mono.delay(Duration.ofMillis(500))
 				                          .doOnNext(v -> live.decrementAndGet())
@@ -1082,7 +1146,6 @@ public class CommonPoolTest {
 		PoolBuilder<String, ?> builder = PoolBuilder
 				.from(Mono.<String>error(new IllegalStateException("boom")))
 				.sizeMax(1)
-				.initialSize(0)
 				.evictionPredicate((poolable, metadata) -> true);
 		AbstractPool<String> pool = configAdjuster.apply(builder);
 
@@ -1096,8 +1159,7 @@ public class CommonPoolTest {
 	void allocatorErrorInConstructorIsThrown(Function<PoolBuilder<Object, ?>, AbstractPool<Object>> configAdjuster) {
 		final PoolBuilder<Object, ?> builder = PoolBuilder
 				.from(Mono.error(new IllegalStateException("boom")))
-				.initialSize(1)
-				.sizeMax(1)
+				.sizeBetween(1, 1)
 				.evictionPredicate((poolable, metadata) -> true);
 
 		assertThatExceptionOfType(IllegalStateException.class)
@@ -1117,8 +1179,7 @@ public class CommonPoolTest {
 
 			PoolBuilder<Closeable, ?> builder = PoolBuilder
 					.from(Mono.just(closeable))
-					.initialSize(1)
-					.sizeMax(1)
+					.sizeBetween(1, 1)
 					.evictionPredicate((poolable, metadata) -> true);
 			AbstractPool<Closeable> pool = configAdjuster.apply(builder);
 
@@ -1245,7 +1306,7 @@ public class CommonPoolTest {
 						return Mono.error(new IllegalStateException("boom"));
 					}
 				}))
-				.initialSize(10)
+				.sizeMin(10)
 				.metricsRecorder(recorder);
 
 		assertThatIllegalStateException()
@@ -1318,7 +1379,7 @@ public class CommonPoolTest {
 						return Mono.delay(Duration.ofMillis(200)).then(Mono.error(new IllegalStateException("boom")));
 					}
 				}))
-				.initialSize(10)
+				.sizeMin(10)
 				.metricsRecorder(recorder);
 
 		assertThatIllegalStateException()
@@ -1511,8 +1572,7 @@ public class CommonPoolTest {
 		//note the starter method here is irrelevant, only the config is created and passed to createPool
 		PoolBuilder<Integer, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(allocCounter::incrementAndGet))
-				.sizeMax(2)
-				.initialSize(2)
+				.sizeBetween(2, 2)
 				.metricsRecorder(recorder);
 		Pool<Integer> pool = configAdjuster.apply(builder);
 
@@ -1541,8 +1601,7 @@ public class CommonPoolTest {
 		//note the starter method here is irrelevant, only the config is created and passed to createPool
 		PoolBuilder<Integer, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(allocCounter::incrementAndGet))
-				.sizeMax(2)
-				.initialSize(2)
+				.sizeBetween(2, 2)
 				.metricsRecorder(recorder);
 		Pool<Integer> pool = configAdjuster.apply(builder);
 

--- a/src/test/java/reactor/pool/SimpleFifoPoolTest.java
+++ b/src/test/java/reactor/pool/SimpleFifoPoolTest.java
@@ -38,6 +38,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.pool.TestUtils.PoolableTest;
+import reactor.test.util.RaceTestUtils;
 import reactor.util.function.Tuple2;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,8 +53,7 @@ class SimpleFifoPoolTest {
     //==utils for package-private config==
     static final PoolConfig<PoolableTest> poolableTestConfig(int minSize, int maxSize, Mono<PoolableTest> allocator) {
         return from(allocator)
-                .initialSize(minSize)
-                .sizeMax(maxSize)
+                .sizeBetween(minSize, maxSize)
                 .releaseHandler(pt -> Mono.fromRunnable(pt::clean))
                 .evictionPredicate((value, metadata) -> !value.isHealthy())
                 .buildConfig();
@@ -61,7 +61,7 @@ class SimpleFifoPoolTest {
 
     static final PoolConfig<PoolableTest> poolableTestConfig(int minSize, int maxSize, Mono<PoolableTest> allocator, Scheduler deliveryScheduler) {
         return from(allocator)
-                .initialSize(minSize)
+                .sizeBetween(minSize, maxSize)
                 .sizeMax(maxSize)
                 .releaseHandler(pt -> Mono.fromRunnable(pt::clean))
                 .evictionPredicate((value, metadata) -> !value.isHealthy())
@@ -72,8 +72,7 @@ class SimpleFifoPoolTest {
     static final PoolConfig<PoolableTest> poolableTestConfig(int minSize, int maxSize, Mono<PoolableTest> allocator,
             Consumer<? super PoolableTest> additionalCleaner) {
         return from(allocator)
-                .initialSize(minSize)
-                .sizeMax(maxSize)
+                .sizeBetween(minSize, maxSize)
                 .releaseHandler(poolableTest -> Mono.fromRunnable(() -> {
                     poolableTest.clean();
                     additionalCleaner.accept(poolableTest);
@@ -466,6 +465,25 @@ class SimpleFifoPoolTest {
             //we expect that only 1 element was created
             assertThat(newCount).as("elements created in round " + i).hasValue(1);
         }
+
+        @Test
+        @Tag("loops")
+        void acquireReleaseRaceWithMinSize_loop() {
+            AtomicInteger newCount = new AtomicInteger();
+            PoolConfig<PoolableTest> testConfig = from(Mono.fromCallable(() -> new PoolableTest(newCount.getAndIncrement())))
+                    .sizeBetween(4, 5)
+                    .buildConfig();
+            SimpleFifoPool<PoolableTest> pool = new SimpleFifoPool<>(testConfig);
+            final Scheduler racer = Schedulers.fromExecutorService(Executors.newFixedThreadPool(2));
+
+            for (int i = 0; i < 100; i++) {
+                RaceTestUtils.race(() -> pool.acquire().block().release().block(),
+                        () -> pool.acquire().block().release().block(),
+                        racer);
+            }
+            //we expect that only 3 element was created
+            assertThat(newCount).as("elements created in total").hasValue(4);
+        }
     }
 
     @Nested
@@ -852,8 +870,7 @@ class SimpleFifoPoolTest {
         AtomicInteger cleanerCount = new AtomicInteger();
         SimpleFifoPool<PoolableTest> pool = new SimpleFifoPool<>(
                 from(Mono.fromCallable(PoolableTest::new))
-                        .initialSize(3)
-                        .sizeMax(3)
+                        .sizeBetween(3, 3)
                         .releaseHandler(p -> Mono.fromRunnable(cleanerCount::incrementAndGet))
                         .evictionPredicate((value, metadata) -> !value.isHealthy())
                         .buildConfig());

--- a/src/test/java/reactor/pool/SimpleLifoPoolTest.java
+++ b/src/test/java/reactor/pool/SimpleLifoPoolTest.java
@@ -55,8 +55,7 @@ class SimpleLifoPoolTest {
     //==utils for package-private config==
     static final PoolConfig<PoolableTest> poolableTestConfig(int minSize, int maxSize, Mono<PoolableTest> allocator) {
         return from(allocator)
-                .initialSize(minSize)
-                .sizeMax(maxSize)
+                .sizeBetween(minSize, maxSize)
                 .releaseHandler(pt -> Mono.fromRunnable(pt::clean))
                 .evictionPredicate((value, metadata) -> !value.isHealthy())
                 .buildConfig();
@@ -64,8 +63,7 @@ class SimpleLifoPoolTest {
 
     static final PoolConfig<PoolableTest> poolableTestConfig(int minSize, int maxSize, Mono<PoolableTest> allocator, Scheduler deliveryScheduler) {
         return from(allocator)
-                .initialSize(minSize)
-                .sizeMax(maxSize)
+                .sizeBetween(minSize, maxSize)
                 .releaseHandler(pt -> Mono.fromRunnable(pt::clean))
                 .evictionPredicate((value, metadata) -> !value.isHealthy())
                 .acquisitionScheduler(deliveryScheduler)
@@ -75,8 +73,7 @@ class SimpleLifoPoolTest {
     static final PoolConfig<PoolableTest> poolableTestConfig(int minSize, int maxSize, Mono<PoolableTest> allocator,
             Consumer<? super PoolableTest> additionalCleaner) {
         return from(allocator)
-                .initialSize(minSize)
-                .sizeMax(maxSize)
+                .sizeBetween(minSize, maxSize)
                 .releaseHandler(poolableTest -> Mono.fromRunnable(() -> {
                     poolableTest.clean();
                     additionalCleaner.accept(poolableTest);
@@ -726,8 +723,7 @@ class SimpleLifoPoolTest {
         AtomicInteger cleanerCount = new AtomicInteger();
         SimpleLifoPool<PoolableTest> pool = new SimpleLifoPool<>(
                 from(Mono.fromCallable(PoolableTest::new))
-                        .initialSize(3)
-                        .sizeMax(3)
+                        .sizeBetween(3, 3)
                         .releaseHandler(p -> Mono.fromRunnable(cleanerCount::incrementAndGet))
                         .evictionPredicate((value, metadata) -> !value.isHealthy())
                         .buildConfig());


### PR DESCRIPTION
This is still work in progress, and notably:
 - [x] ~Should we add a `warmup` API to explicitly warmup without the need for an `acquire`+`release`? this could replace the constructor blocking warmup~ see #5 
 - [x] Should the `getPermit(0)` be wired to return the min, for a warmup's benefit
 - [ ] Do we need to "rehydrate" on destroy handler application as well? (knowning that the approach is currently to rehydrate during `acquire`)

@smaldini @nebhale if you have any comments (on these questions or the current state of the PR itself, despite being a draft).