### PR TITLE
fix #5 Remove blocking allocations in constructor and replace with warmup API

### DIFF
--- a/src/main/java/reactor/pool/AllocationStrategies.java
+++ b/src/main/java/reactor/pool/AllocationStrategies.java
@@ -72,6 +72,7 @@ final class AllocationStrategies {
         static final AtomicIntegerFieldUpdater<SizeBasedAllocationStrategy> PERMITS = AtomicIntegerFieldUpdater.newUpdater(SizeBasedAllocationStrategy.class, "permits");
 
         SizeBasedAllocationStrategy(int max) {
+            if (max < 1) throw new IllegalArgumentException("max must be strictly positive");
             this.max = Math.max(1, max);
             PERMITS.lazySet(this, this.max);
         }

--- a/src/main/java/reactor/pool/AllocationStrategy.java
+++ b/src/main/java/reactor/pool/AllocationStrategy.java
@@ -35,11 +35,15 @@ public interface AllocationStrategy {
     /**
      * Try to get the permission to allocate a {@code desired} positive number of new resources. Returns the permissible
      * number of resources which MUST be created (otherwise the internal live counter of the strategy might be off).
-     * This permissible number might be zero. Once a resource is discarded from the pool, it must
-     * update the strategy using {@link #returnPermits(int)} (which can happen in batches or with value {@literal 1}).
+     * This permissible number might be zero, and it can also be a greater number than {@code desired}, which could for
+     * example denote a minimum warmed-up size for the pool to maintain (see below).
+     * Once a resource is discarded from the pool, it must update the strategy using {@link #returnPermits(int)}
+     * (which can happen in batches or with value {@literal 1}).
+     * <p>
+     * For the warming up case, the typical pattern would be to call this method with a {@code desired} of zero.
      *
      * @param desired the desired number of new resources
-     * @return the acceptable number of new resources, might be zero
+     * @return the actual number of new resources that MUST be created, can be 0 and can be more than {@code desired}
      */
     int getPermits(int desired);
 
@@ -47,6 +51,14 @@ public interface AllocationStrategy {
      * @return a best estimate of the number of permits currently granted, between 0 and {@link Integer#MAX_VALUE}
      */
     int permitGranted();
+
+    /**
+     * Return the minimum number of permits this strategy tries to maintain granted
+     * (reflecting a minimal size for the pool), or {@code 0} for scale-to-zero.
+     *
+     * @return the minimum number of permits this strategy tries to maintain, or {@code 0}
+     */
+    int permitMinimum();
 
     /**
      * @return the maximum number of permits this strategy can grant in total, or {@link Integer#MAX_VALUE} for unbounded.

--- a/src/main/java/reactor/pool/DefaultPoolConfig.java
+++ b/src/main/java/reactor/pool/DefaultPoolConfig.java
@@ -33,7 +33,6 @@ import reactor.core.scheduler.Scheduler;
 public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 
 	protected final Mono<POOLABLE>                                allocator;
-	protected final int                                           initialSize;
 	protected final AllocationStrategy                            allocationStrategy;
 	protected final int                                           maxPending;
 	protected final Function<POOLABLE, ? extends Publisher<Void>> releaseHandler;
@@ -43,7 +42,6 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 	protected final PoolMetricsRecorder                           metricsRecorder;
 
 	public DefaultPoolConfig(Mono<POOLABLE> allocator,
-			int initialSize,
 			AllocationStrategy allocationStrategy,
 			int maxPending,
 			Function<POOLABLE, ? extends Publisher<Void>> releaseHandler,
@@ -52,7 +50,6 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 			Scheduler acquisitionScheduler,
 			PoolMetricsRecorder metricsRecorder) {
 		this.allocator = allocator;
-		this.initialSize = initialSize;
 		this.allocationStrategy = allocationStrategy;
 		this.maxPending = maxPending;
 		this.releaseHandler = releaseHandler;
@@ -72,7 +69,6 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 		if (toCopy instanceof DefaultPoolConfig) {
 			DefaultPoolConfig<POOLABLE> toCopyDpc = (DefaultPoolConfig<POOLABLE>) toCopy;
 			this.allocator = toCopyDpc.allocator;
-			this.initialSize = toCopyDpc.initialSize;
 			this.allocationStrategy = toCopyDpc.allocationStrategy;
 			this.maxPending = toCopyDpc.maxPending;
 			this.releaseHandler = toCopyDpc.releaseHandler;
@@ -83,7 +79,6 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 		}
 		else {
 			this.allocator = toCopy.allocator();
-			this.initialSize = toCopy.initialSize();
 			this.allocationStrategy = toCopy.allocationStrategy();
 			this.maxPending = toCopy.maxPending();
 			this.releaseHandler = toCopy.releaseHandler();
@@ -97,11 +92,6 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 	@Override
 	public Mono<POOLABLE> allocator() {
 		return this.allocator;
-	}
-
-	@Override
-	public int initialSize() {
-		return this.initialSize;
 	}
 
 	@Override

--- a/src/main/java/reactor/pool/Pool.java
+++ b/src/main/java/reactor/pool/Pool.java
@@ -31,6 +31,25 @@ import reactor.core.publisher.Mono;
 public interface Pool<POOLABLE> extends Disposable {
 
     /**
+     * Warms up the {@link Pool}, if needed. This typically instructs the pool to check for a minimum size and allocate
+     * necessary objects when the minimum is not reached. The resulting {@link Mono} emits the number of extra resources
+     * it created as a result of the {@link PoolBuilder#sizeBetween(int, int) allocation minimum}.
+     * <p>
+     * Note that no work nor allocation is performed until the {@link Mono} is subscribed to.
+     * <p>
+     * Implementations MAY include more behavior, but there is no restriction on the way this method is called by users
+     * (it should be possible to call it at any time, as many times as needed or not at all).
+     *
+     * @apiNote this API is intended to easily reach the minimum allocated size (see {@link PoolBuilder#sizeMin(int)})
+     * without paying that cost on the first {@link #acquire()}. However, implementors should also consider creating
+     * the extra resources needed to honor that minimum during the acquire, as one cannot rely on the user calling
+     * warmup() consistently.
+     *
+     * @return a cold {@link Mono} that triggers resource warmup and emits the number of warmed up resources
+     */
+    Mono<Integer> warmup();
+
+    /**
      * Manually acquire a {@code POOLABLE} from the pool upon subscription and become responsible for its release.
      * The object is wrapped in a {@link PooledRef} which can be used for manually releasing the object back to the pool
      * or invalidating it. As a result, you MUST maintain a reference to it throughout the code that makes use of the

--- a/src/main/java/reactor/pool/Pool.java
+++ b/src/main/java/reactor/pool/Pool.java
@@ -15,14 +15,14 @@
  */
 package reactor.pool;
 
+import java.time.Duration;
+import java.util.function.Function;
+
 import org.reactivestreams.Publisher;
+
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
-import java.time.Duration;
-import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * A reactive pool of objects.
@@ -85,7 +85,7 @@ public interface Pool<POOLABLE> extends Disposable {
      */
     Mono<PooledRef<POOLABLE>> acquire(Duration timeout);
 
-    /**
+	/**
      * Acquire a {@code POOLABLE} object from the pool upon subscription and declaratively use it, automatically releasing
      * the object back to the pool once the derived usage pipeline terminates or is cancelled. This acquire-use-and-release
      * scope is represented by a user provided {@link Function}.

--- a/src/main/java/reactor/pool/PoolConfig.java
+++ b/src/main/java/reactor/pool/PoolConfig.java
@@ -39,11 +39,6 @@ public interface PoolConfig<POOLABLE> {
 	Mono<POOLABLE> allocator();
 
 	/**
-	 * The minimum number of objects a {@link Pool} should create at initialization.
-	 */
-	int initialSize();
-
-	/**
 	 * {@link AllocationStrategy} defines a strategy / limit for the number of pooled object to allocate.
 	 */
 	AllocationStrategy allocationStrategy();

--- a/src/main/java/reactor/pool/SimplePool.java
+++ b/src/main/java/reactor/pool/SimplePool.java
@@ -65,13 +65,10 @@ abstract class SimplePool<POOLABLE> extends AbstractPool<POOLABLE> {
     SimplePool(PoolConfig<POOLABLE> poolConfig) {
         super(poolConfig, Loggers.getLogger(SimplePool.class));
         this.elements = Queues.<QueuePooledRef<POOLABLE>>unboundedMultiproducer().get();
-
-        //TODO remove that from constructor (eg. warmup official API)?
-        //TODO modify tests accordingly
-        warmup().block();
     }
 
-    private Mono<Integer> warmup() {
+    @Override
+    public Mono<Integer> warmup() {
         if (poolConfig.allocationStrategy().permitMinimum() > 0) {
             return Mono.defer(() -> {
                 int initSize = poolConfig.allocationStrategy().getPermits(0);

--- a/src/test/java/reactor/pool/AllocationStrategiesTest.java
+++ b/src/test/java/reactor/pool/AllocationStrategiesTest.java
@@ -44,84 +44,181 @@ class AllocationStrategiesTest {
 
     private static final Logger LOG = Loggers.getLogger(AllocationStrategies.class);
 
-    @DisplayName("allocatingMax")
+    @DisplayName("allocatingSize")
     @Nested
-    class AllocatingMaxTest {
+    class AllocatingSizeTest {
 
         @Test
         void negativeMaxThrows() {
             assertThatIllegalArgumentException()
-                    .isThrownBy(() -> new SizeBasedAllocationStrategy(-1))
+                    .isThrownBy(() -> new SizeBasedAllocationStrategy(0, -1))
                     .withMessage("max must be strictly positive");
         }
 
         @Test
         void zeroMaxThrows() {
             assertThatIllegalArgumentException()
-                    .isThrownBy(() -> new SizeBasedAllocationStrategy(0))
+                    .isThrownBy(() -> new SizeBasedAllocationStrategy(0, 0))
                     .withMessage("max must be strictly positive");
         }
 
         @Test
-        void onePermitCount() {
-            AllocationStrategy test = new SizeBasedAllocationStrategy(1);
+        void negativeMinThrows() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new SizeBasedAllocationStrategy(-1, 0))
+                    .withMessage("min must be positive or zero");
+        }
+
+        @Test
+        void minMoreThanMaxThrows() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new SizeBasedAllocationStrategy(2, 1))
+                    .withMessage("min must be less than or equal to max");
+        }
+
+        @Test
+        void minDoesntInfluenceInitialPermitCount() {
+            AllocationStrategy test = new SizeBasedAllocationStrategy(2, 5);
+
+            assertThat(test.estimatePermitCount()).isEqualTo(5);
+        }
+
+        @Test
+        void atMostOnePermitCount() {
+            AllocationStrategy test = new SizeBasedAllocationStrategy(0, 1);
 
             assertThat(test.estimatePermitCount()).isOne();
         }
 
         @Test
-        void onePermitGet() {
-            AllocationStrategy test = new SizeBasedAllocationStrategy(1);
+        void atMostOnePermitGet() {
+            AllocationStrategy test = new SizeBasedAllocationStrategy(0, 1);
 
             assertThat(test.getPermits(1)).as("first try").isOne();
             assertThat(test.getPermits(1)).as("second try").isZero();
         }
 
         @Test
-        void onePermitGetDesired() {
-            AllocationStrategy test = new SizeBasedAllocationStrategy(1);
+        void atMostOnePermitGetDesired() {
+            AllocationStrategy test = new SizeBasedAllocationStrategy(0, 1);
 
             assertThat(test.getPermits(100)).as("desired 100").isOne();
             assertThat(test.getPermits(1)).as("desired 1 more").isZero();
         }
 
         @Test
-        void getPermitDesiredZero() {
-            AllocationStrategy test = new SizeBasedAllocationStrategy(1);
+        void getPermitDesiredZeroWithNoMin() {
+            AllocationStrategy test = new SizeBasedAllocationStrategy(0, 1);
 
             assertThat(test.getPermits(0)).isZero();
         }
 
         @Test
+        void getPermitDesiredZeroWithMin() {
+            AllocationStrategy test = new SizeBasedAllocationStrategy(4, 8);
+
+            assertThat(test.getPermits(0)).isEqualTo(4);
+        }
+
+        @Test
+        void getPermitDesiredZeroWithMinPartiallyReached() {
+            AllocationStrategy test = new SizeBasedAllocationStrategy(4, 8);
+            //first getPermit returns min, but we can return some of these permits
+            assertThat(test.getPermits(0)).as("initial warmup").isEqualTo(4);
+
+            test.returnPermits(3);
+
+            assertThat(test.getPermits(0)).as("partial warmup").isEqualTo(3);
+        }
+
+        @Test
         void getPermitDesiredNegative() {
-            AllocationStrategy test = new SizeBasedAllocationStrategy(1);
+            AllocationStrategy test = new SizeBasedAllocationStrategy(1, 2);
 
             assertThat(test.getPermits(-1)).isZero();
         }
 
+        //TODO should we be more strict in enforcing max here?
         @Test
-        void returnPermitCanGoOverMax() {
-            final AllocationStrategy test = new SizeBasedAllocationStrategy(1);
+        void misuseReturnPermitCanGoOverMax() {
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(0, 1);
 
             test.returnPermits(1);
 
             assertThat(test.estimatePermitCount()).isEqualTo(2);
         }
 
+        //TODO should we be more strict in enforcing max here?
         @Test
-        void returnPermitsCanGoOverMax() {
-            final AllocationStrategy test = new SizeBasedAllocationStrategy(1);
+        void misuseReturnPermitsCanGoOverMax() {
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(0, 1);
 
             test.returnPermits(100);
 
             assertThat(test.estimatePermitCount()).isEqualTo(101);
         }
 
+        @Test
+        void minMaxPermitScenario1() {
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(2, 3);
+
+            assertThat(test.estimatePermitCount()).as("initial state").isEqualTo(3);
+
+            assertThat(test.getPermits(1)).as("granted for get(1)").isEqualTo(2);
+            assertThat(test.estimatePermitCount()).as("after get").isOne();
+
+            assertThat(test.getPermits(2)).as("granted for get(2)").isOne();
+            assertThat(test.estimatePermitCount()).as("after second get").isZero();
+
+            assertThat(test.getPermits(1)).as("get when max reached").isZero();
+            assertThat(test.estimatePermitCount()).as("after no-op get").isZero();
+        }
+
+        @Test
+        void minMaxPermitScenario2() {
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(4, 8);
+
+            int firstGet = test.getPermits(1);
+            test.returnPermits(1);
+            test.returnPermits(2);
+            int secondGet = test.getPermits(1);
+            int drainingGet = test.getPermits(4);
+            int starvedGet = test.getPermits(1);
+
+            assertThat(firstGet).as("first getPermits(1)").isEqualTo(4);
+            assertThat(secondGet).as("second getPermits(1)").isEqualTo(3);
+            assertThat(drainingGet).as("draining getPermits(4)").isEqualTo(4);
+            assertThat(starvedGet).as("starved getPermits(1)").isZero();
+        }
+
+        @Test
+        void minMaxPermitWhenPartiallyStarved() {
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(4, 8);
+            test.getPermits(6);
+
+            assertThat(test.getPermits(4)).isEqualTo(2);
+        }
+
+        @Test
+        void minMaxPermitWhenTotallyStarved() {
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(4, 8);
+            test.getPermits(8);
+
+            assertThat(test.getPermits(4)).isZero();
+        }
+
+        @Test
+        void minMaxPermitWhenDesiredGreaterThanMin() {
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(4, 8);
+
+            assertThat(test.getPermits(5)).isEqualTo(5);
+        }
+
         @ParameterizedTest(name = "{0} workers")
         @ValueSource(ints = {5, 10, 20})
         @Tag("race")
         void raceGetPermit(int workerCount) throws InterruptedException {
-            final AllocationStrategy test = new SizeBasedAllocationStrategy(10);
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(0, 10);
 
             LongAdder counter = new LongAdder();
             ExecutorService es = Executors.newFixedThreadPool(workerCount);
@@ -146,7 +243,7 @@ class AllocationStrategiesTest {
         @ValueSource(ints = {5, 10, 20})
         @Tag("race")
         void racePermitsRandom(int workerCount, TestInfo testInfo) throws InterruptedException {
-            final AllocationStrategy test = new SizeBasedAllocationStrategy(10);
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(0, 10);
 
             LongAdder counter = new LongAdder();
             LongAdder gotZeroCounter = new LongAdder();
@@ -177,7 +274,7 @@ class AllocationStrategiesTest {
         @ValueSource(ints = {5, 10, 20})
         @Tag("race")
         void raceMixGetPermitWithGetRandomPermits(int workerCount, TestInfo testInfo) throws InterruptedException {
-            final AllocationStrategy test = new SizeBasedAllocationStrategy(10);
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(0, 10);
 
             LongAdder usedGetRandomPermits = new LongAdder();
             LongAdder usedGetPermit = new LongAdder();
@@ -223,7 +320,7 @@ class AllocationStrategiesTest {
         @ValueSource(ints = {5, 10, 20})
         @Tag("race")
         void racePermitsRandomWithInnerLoop(int workerCount, TestInfo testInfo) throws InterruptedException {
-            final AllocationStrategy test = new SizeBasedAllocationStrategy(10);
+            final AllocationStrategy test = new SizeBasedAllocationStrategy(0, 10);
 
             LongAdder counter = new LongAdder();
             LongAdder gotZeroCounter = new LongAdder();
@@ -250,6 +347,8 @@ class AllocationStrategiesTest {
             assertThat(counter.sum()).as("permits acquired").isBetween(1_000_000L, 10_000_000L);
             assertThat(test.estimatePermitCount()).as("end permit count").isEqualTo(10);
         }
+
+        //TODO race tests with a minimum
     }
 
     @DisplayName("unbounded")

--- a/src/test/java/reactor/pool/AllocationStrategiesTest.java
+++ b/src/test/java/reactor/pool/AllocationStrategiesTest.java
@@ -35,6 +35,7 @@ import reactor.util.Logger;
 import reactor.util.Loggers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
  * @author Simon Baslé
@@ -48,17 +49,17 @@ class AllocationStrategiesTest {
     class AllocatingMaxTest {
 
         @Test
-        void negativeMaxGivesOnePermit() {
-            AllocationStrategy test = new SizeBasedAllocationStrategy(-1);
-
-            assertThat(test.estimatePermitCount()).isOne();
+        void negativeMaxThrows() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new SizeBasedAllocationStrategy(-1))
+                    .withMessage("max must be strictly positive");
         }
 
         @Test
-        void zeroMaxGivesOnePermit() {
-            AllocationStrategy test = new SizeBasedAllocationStrategy(0);
-
-            assertThat(test.estimatePermitCount()).isOne();
+        void zeroMaxThrows() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new SizeBasedAllocationStrategy(0))
+                    .withMessage("max must be strictly positive");
         }
 
         @Test

--- a/src/test/java/reactor/pool/PoolBuilderTest.java
+++ b/src/test/java/reactor/pool/PoolBuilderTest.java
@@ -128,6 +128,10 @@ class PoolBuilderTest {
             this.config = config;
         }
 
+        public Mono<Integer> warmup() {
+            return Mono.just(0);
+        }
+
         @Override
         public Mono<PooledRef<T>> acquire() {
             return null;

--- a/src/test/java/reactor/pool/SimpleFifoPoolTest.java
+++ b/src/test/java/reactor/pool/SimpleFifoPoolTest.java
@@ -193,8 +193,9 @@ class SimpleFifoPoolTest {
                     Mono.fromCallable(PoolableTest::new)
                         .subscribeOn(Schedulers.newParallel("poolable test allocator")));
             SimpleFifoPool<PoolableTest> pool = new SimpleFifoPool<>(testConfig);
+            pool.warmup().block();
 
-            //the pool is started with one available element
+            //the pool is started and warmed up with one available element
             //we prepare to acquire it
             Mono<PooledRef<PoolableTest>> borrower = pool.acquire();
             CountDownLatch latch = new CountDownLatch(1);
@@ -580,8 +581,9 @@ class SimpleFifoPoolTest {
                     Mono.fromCallable(PoolableTest::new)
                         .subscribeOn(Schedulers.newParallel("poolable test allocator")));
             SimpleFifoPool<PoolableTest> pool = new SimpleFifoPool<>(testConfig);
+            pool.warmup().block();
 
-            //the pool is started with one available element
+            //the pool is started and warmed up with one available element
             //we prepare to acquire it
             Mono<PoolableTest> borrower = Mono.fromDirect(pool.withPoolable(Mono::just));
             CountDownLatch latch = new CountDownLatch(1);

--- a/src/test/java/reactor/pool/SimpleLifoPoolTest.java
+++ b/src/test/java/reactor/pool/SimpleLifoPoolTest.java
@@ -55,8 +55,7 @@ class SimpleLifoPoolTest {
     //==utils for package-private config==
     static final PoolConfig<PoolableTest> poolableTestConfig(int minSize, int maxSize, Mono<PoolableTest> allocator) {
         return from(allocator)
-                .initialSize(minSize)
-                .sizeMax(maxSize)
+                .sizeBetween(minSize, maxSize)
                 .releaseHandler(pt -> Mono.fromRunnable(pt::clean))
                 .evictionPredicate((value, metadata) -> !value.isHealthy())
                 .buildConfig();
@@ -64,8 +63,7 @@ class SimpleLifoPoolTest {
 
     static final PoolConfig<PoolableTest> poolableTestConfig(int minSize, int maxSize, Mono<PoolableTest> allocator, Scheduler deliveryScheduler) {
         return from(allocator)
-                .initialSize(minSize)
-                .sizeMax(maxSize)
+                .sizeBetween(minSize, maxSize)
                 .releaseHandler(pt -> Mono.fromRunnable(pt::clean))
                 .evictionPredicate((value, metadata) -> !value.isHealthy())
                 .acquisitionScheduler(deliveryScheduler)
@@ -75,8 +73,7 @@ class SimpleLifoPoolTest {
     static final PoolConfig<PoolableTest> poolableTestConfig(int minSize, int maxSize, Mono<PoolableTest> allocator,
             Consumer<? super PoolableTest> additionalCleaner) {
         return from(allocator)
-                .initialSize(minSize)
-                .sizeMax(maxSize)
+                .sizeBetween(minSize, maxSize)
                 .releaseHandler(poolableTest -> Mono.fromRunnable(() -> {
                     poolableTest.clean();
                     additionalCleaner.accept(poolableTest);
@@ -726,8 +723,7 @@ class SimpleLifoPoolTest {
         AtomicInteger cleanerCount = new AtomicInteger();
         SimpleLifoPool<PoolableTest> pool = new SimpleLifoPool<>(
                 from(Mono.fromCallable(PoolableTest::new))
-                        .initialSize(3)
-                        .sizeMax(3)
+                        .sizeBetween(3, 3)
                         .releaseHandler(p -> Mono.fromRunnable(cleanerCount::incrementAndGet))
                         .evictionPredicate((value, metadata) -> !value.isHealthy())
                         .buildConfig());

--- a/src/test/java/reactor/pool/SimpleLifoPoolTest.java
+++ b/src/test/java/reactor/pool/SimpleLifoPoolTest.java
@@ -187,8 +187,9 @@ class SimpleLifoPoolTest {
                     Mono.fromCallable(PoolableTest::new)
                         .subscribeOn(Schedulers.newParallel("poolable test allocator")));
             SimpleLifoPool<PoolableTest> pool = new SimpleLifoPool<>(testConfig);
+            pool.warmup().block();
 
-            //the pool is started with one available element
+            //the pool is started and warmed up with one available element
             //we prepare to acquire it
             Mono<PooledRef<PoolableTest>> borrower = pool.acquire();
             CountDownLatch latch = new CountDownLatch(1);
@@ -493,8 +494,9 @@ class SimpleLifoPoolTest {
                     Mono.fromCallable(PoolableTest::new)
                         .subscribeOn(Schedulers.newParallel("poolable test allocator")));
             SimpleLifoPool<PoolableTest> pool = new SimpleLifoPool<>(testConfig);
+            pool.warmup().block();
 
-            //the pool is started with one available element
+            //the pool is started and warmed up with one available element
             //we prepare to acquire it
             Mono<PoolableTest> borrower = Mono.fromDirect(pool.withPoolable(Mono::just));
             CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION
In progress: for now this focuses on the API, which is still called in a blocking fashion inside the constructor. Depends on #56.