### PR TITLE
fix #60 Separate Clock and PoolMetricsRecorder

### DIFF
--- a/src/main/java/reactor/pool/DefaultPoolConfig.java
+++ b/src/main/java/reactor/pool/DefaultPoolConfig.java
@@ -16,6 +16,7 @@
 
 package reactor.pool;
 
+import java.time.Clock;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 
@@ -40,6 +41,7 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 	protected final BiPredicate<POOLABLE, PooledRefMetadata>      evictionPredicate;
 	protected final Scheduler                                     acquisitionScheduler;
 	protected final PoolMetricsRecorder                           metricsRecorder;
+	protected final Clock                                         clock;
 
 	public DefaultPoolConfig(Mono<POOLABLE> allocator,
 			AllocationStrategy allocationStrategy,
@@ -48,7 +50,8 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 			Function<POOLABLE, ? extends Publisher<Void>> destroyHandler,
 			BiPredicate<POOLABLE, PooledRefMetadata> evictionPredicate,
 			Scheduler acquisitionScheduler,
-			PoolMetricsRecorder metricsRecorder) {
+			PoolMetricsRecorder metricsRecorder,
+			Clock clock) {
 		this.allocator = allocator;
 		this.allocationStrategy = allocationStrategy;
 		this.maxPending = maxPending;
@@ -57,6 +60,7 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 		this.evictionPredicate = evictionPredicate;
 		this.acquisitionScheduler = acquisitionScheduler;
 		this.metricsRecorder = metricsRecorder;
+		this.clock = clock;
 	}
 
 	/**
@@ -76,6 +80,7 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 			this.evictionPredicate = toCopyDpc.evictionPredicate;
 			this.acquisitionScheduler = toCopyDpc.acquisitionScheduler;
 			this.metricsRecorder = toCopyDpc.metricsRecorder;
+			this.clock = toCopyDpc.clock;
 		}
 		else {
 			this.allocator = toCopy.allocator();
@@ -86,6 +91,7 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 			this.evictionPredicate = toCopy.evictionPredicate();
 			this.acquisitionScheduler = toCopy.acquisitionScheduler();
 			this.metricsRecorder = toCopy.metricsRecorder();
+			this.clock = toCopy.clock();
 		}
 	}
 
@@ -127,5 +133,10 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 	@Override
 	public PoolMetricsRecorder metricsRecorder() {
 		return this.metricsRecorder;
+	}
+
+	@Override
+	public Clock clock() {
+		return this.clock;
 	}
 }

--- a/src/main/java/reactor/pool/NoOpPoolMetricsRecorder.java
+++ b/src/main/java/reactor/pool/NoOpPoolMetricsRecorder.java
@@ -29,16 +29,6 @@ final class NoOpPoolMetricsRecorder implements PoolMetricsRecorder {
     }
 
     @Override
-    public long now() {
-        return 0L;
-    }
-
-    @Override
-    public long measureTime(long startTimeMillis) {
-        return 0;
-    }
-
-    @Override
     public void recordAllocationSuccessAndLatency(long latencyMs) {
 
     }

--- a/src/main/java/reactor/pool/PoolConfig.java
+++ b/src/main/java/reactor/pool/PoolConfig.java
@@ -16,6 +16,7 @@
 
 package reactor.pool;
 
+import java.time.Clock;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 
@@ -90,5 +91,11 @@ public interface PoolConfig<POOLABLE> {
 	 * implementations.
 	 */
 	PoolMetricsRecorder metricsRecorder();
+
+	/**
+	 * The {@link java.time.Clock} to use to timestamp pool lifecycle events like allocation
+	 * and eviction, which can influence eg. the {@link #evictionPredicate()}.
+	 */
+	Clock clock();
 
 }

--- a/src/main/java/reactor/pool/PoolMetricsRecorder.java
+++ b/src/main/java/reactor/pool/PoolMetricsRecorder.java
@@ -19,25 +19,12 @@ package reactor.pool;
  * An interface representing ways for {@link Pool} to collect instrumentation data.
  * Some methods are pool-implementation specific.
  * <p>
- * Additionally wraps the concept of a clock, with {@link #now()} to get the current time with milliseconds
- * resolution and {@link #measureTime(long)} to get the elapsed time.
+ * Note this doesn't include the concepts of measuring timings, which should be the
+ * responsibility of a {@link java.time.Clock}.
  *
  * @author Simon Baslé
  */
 public interface PoolMetricsRecorder {
-
-	/**
-	 * Get the elapsed time in milliseconds between {@link #now()} and the given starting time.
-	 *
-	 * @param startTimeMillis the starting time initially obtained via {@link #now()}
-	 * @return the elapsed time in milliseconds
-	 */
-	long measureTime(long startTimeMillis);
-
-	/**
-	 * Get a starting time with milliseconds resolution.
-	 */
-	long now();
 
 	/**
 	 * Record a latency for successful allocation. Implies incrementing an allocation success counter as well.

--- a/src/test/java/reactor/pool/CommonPoolTest.java
+++ b/src/test/java/reactor/pool/CommonPoolTest.java
@@ -1395,7 +1395,8 @@ public class CommonPoolTest {
 					}
 				}))
 				.sizeMin(10)
-				.metricsRecorder(recorder);
+				.metricsRecorder(recorder)
+				.clock(recorder);
 		AbstractPool<String> pool = configAdjuster.apply(builder);
 
 		assertThatIllegalStateException()
@@ -1426,7 +1427,8 @@ public class CommonPoolTest {
 						return Mono.error(new IllegalStateException("boom"));
 					}
 				}))
-				.metricsRecorder(recorder);
+				.metricsRecorder(recorder)
+				.clock(recorder);
 		Pool<String> pool = configAdjuster.apply(builder);
 
 		pool.acquire().block(); //success
@@ -1469,7 +1471,8 @@ public class CommonPoolTest {
 					}
 				}))
 				.sizeMin(10)
-				.metricsRecorder(recorder);
+				.metricsRecorder(recorder)
+				.clock(recorder);
 		AbstractPool<String> pool = configAdjuster.apply(builder);
 
 		assertThatIllegalStateException()
@@ -1500,7 +1503,8 @@ public class CommonPoolTest {
 						return Mono.delay(Duration.ofMillis(200)).then(Mono.error(new IllegalStateException("boom")));
 					}
 				}))
-				.metricsRecorder(recorder);
+				.metricsRecorder(recorder)
+				.clock(recorder);
 		Pool<String> pool = configAdjuster.apply(builder);
 
 		pool.acquire().block(); //success
@@ -1539,7 +1543,8 @@ public class CommonPoolTest {
 						return Mono.empty();
 					}
 				})
-				.metricsRecorder(recorder);
+				.metricsRecorder(recorder)
+				.clock(recorder);
 		Pool<String> pool = configAdjuster.apply(builder);
 
 		pool.acquire().flatMap(PooledRef::release).block();
@@ -1575,7 +1580,8 @@ public class CommonPoolTest {
 						return Mono.empty();
 					}
 				})
-				.metricsRecorder(recorder);
+				.metricsRecorder(recorder)
+				.clock(recorder);
 		Pool<String> pool = configAdjuster.apply(builder);
 
 		pool.acquire().flatMap(PooledRef::release).block();
@@ -1604,7 +1610,8 @@ public class CommonPoolTest {
 		PoolBuilder<String, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(() -> content.getAndSet("bar")))
 				.evictionPredicate((poolable, metadata) -> "foo".equals(poolable))
-				.metricsRecorder(recorder);
+				.metricsRecorder(recorder)
+				.clock(recorder);
 		Pool<String> pool = configAdjuster.apply(builder);
 
 		pool.acquire().flatMap(PooledRef::release).block();
@@ -1627,7 +1634,8 @@ public class CommonPoolTest {
 				.sizeMax(2)
 				.evictionPredicate((poolable, metadata) -> metadata.acquireCount() >= 2)
 				.destroyHandler(i -> Mono.fromRunnable(destroyCounter::incrementAndGet))
-				.metricsRecorder(recorder);
+				.metricsRecorder(recorder)
+				.clock(recorder);
 		Pool<Integer> pool = configAdjuster.apply(builder);
 
 		//first round
@@ -1663,7 +1671,8 @@ public class CommonPoolTest {
 		PoolBuilder<Integer, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(allocCounter::incrementAndGet))
 				.sizeBetween(2, 2)
-				.metricsRecorder(recorder);
+				.metricsRecorder(recorder)
+				.clock(recorder);
 		Pool<Integer> pool = configAdjuster.apply(builder);
 		pool.warmup().block();
 
@@ -1693,7 +1702,8 @@ public class CommonPoolTest {
 		PoolBuilder<Integer, ?> builder = PoolBuilder
 				.from(Mono.fromCallable(allocCounter::incrementAndGet))
 				.sizeBetween(2, 2)
-				.metricsRecorder(recorder);
+				.metricsRecorder(recorder)
+				.clock(recorder);
 		Pool<Integer> pool = configAdjuster.apply(builder);
 		pool.warmup().block();
 


### PR DESCRIPTION
This commit removes the responsibility of timestamping from the
PoolMetricsRecorder and puts it on a Clock instance that can be passed
to the PoolBuilder.

`now()` and `measureTime(long)` have been removed from the former, and
pool implementations now use the configured Clock instead. The default
clock is `Clock.SystemUTC()` (since only the millis() method is used).