### PR TITLE
Standardize docs and fix a typo

### DIFF
--- a/src/main/java/reactor/pool/AllocationStrategy.java
+++ b/src/main/java/reactor/pool/AllocationStrategy.java
@@ -61,7 +61,7 @@ public interface AllocationStrategy {
     int permitMinimum();
 
     /**
-     * @return the maximum number of permits this strategy can grant in total, or {@link Integer#MAX_VALUE} for unbounded.
+     * @return the maximum number of permits this strategy can grant in total, or {@link Integer#MAX_VALUE} for unbounded
      */
     int permitMaximum();
 

--- a/src/main/java/reactor/pool/DefaultPoolConfig.java
+++ b/src/main/java/reactor/pool/DefaultPoolConfig.java
@@ -67,7 +67,7 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 	 * Copy constructor for the benefit of specializations of {@link PoolConfig}.
 	 *
 	 * @param toCopy the original {@link PoolConfig} to copy (only standard {@link PoolConfig}
-	 * options are copied).
+	 * options are copied)
 	 */
 	protected DefaultPoolConfig(PoolConfig<POOLABLE> toCopy) {
 		if (toCopy instanceof DefaultPoolConfig) {

--- a/src/main/java/reactor/pool/InstrumentedPool.java
+++ b/src/main/java/reactor/pool/InstrumentedPool.java
@@ -82,7 +82,7 @@ public interface InstrumentedPool<POOLABLE> extends Pool<POOLABLE> {
 		 * <p>
 		 * A {@link Pool} might be unbounded, in which case this method returns {@link Integer#MAX_VALUE}.
 		 *
-		 * @return the maximum number of live resources that can be allocated by this {@link Pool}.
+		 * @return the maximum number of live resources that can be allocated by this {@link Pool}
 		 */
 		int getMaxAllocatedSize();
 
@@ -94,7 +94,7 @@ public interface InstrumentedPool<POOLABLE> extends Pool<POOLABLE> {
 		 * A {@link Pool} pending queue might be unbounded, in which case this method returns
 		 * {@link Integer#MAX_VALUE}.
 		 *
-		 * @return the maximum number of pending acquire that can be enqueued by this {@link Pool}.
+		 * @return the maximum number of pending acquire that can be enqueued by this {@link Pool}
 		 */
 		int getMaxPendingAcquireSize();
 	}

--- a/src/main/java/reactor/pool/Pool.java
+++ b/src/main/java/reactor/pool/Pool.java
@@ -117,9 +117,9 @@ public interface Pool<POOLABLE> extends Disposable {
      * acquisition entirely or will translate to a {@link PooledRef#release() release} of the {@code POOLABLE}.
      *
      * @param scopeFunction the {@link Function} to apply to the {@link Mono} delivering the POOLABLE to instantiate and
-     *                      trigger a processing pipeline around it.
+     *                      trigger a processing pipeline around it
      * @return a {@link Flux}, each subscription to which represents an individual act of acquiring a pooled object,
-     * processing it as declared in {@code scopeFunction} and automatically releasing it.
+     * processing it as declared in {@code scopeFunction} and automatically releasing it
      * @see #acquire()
      */
     default <V> Flux<V> withPoolable(Function<POOLABLE, Publisher<V>> scopeFunction) {

--- a/src/main/java/reactor/pool/PoolBuilder.java
+++ b/src/main/java/reactor/pool/PoolBuilder.java
@@ -169,7 +169,7 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
      * Defaults to never evicting (a {@link BiPredicate} that always returns false).
      *
      * @param evictionPredicate a {@link Predicate} that returns {@code true} if the resource is unfit for the pool and should
-     * be destroyed, {@code false} if it should be put back into the pool.
+     * be destroyed, {@code false} if it should be put back into the pool
      * @return this {@link Pool} builder
      * @see #evictionIdle(Duration)
      */
@@ -202,7 +202,7 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
      * <p>
      * This is the default.
      *
-     * @return a builder of {@link Pool} with no maximum pending queue size.
+     * @return a builder of {@link Pool} with no maximum pending queue size
      */
     public PoolBuilder<T, CONF> maxPendingAcquireUnbounded() {
         this.maxPending = -1;
@@ -304,7 +304,7 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
      * {@link Pool#acquire()} {@link Mono Mono} that was pending is served first
      * whenever a resource becomes available.
      *
-     * @return a builder of {@link Pool} with LIFO pending acquire ordering.
+     * @return a builder of {@link Pool} with LIFO pending acquire ordering
      */
     public InstrumentedPool<T> lifo() {
         return build(SimpleLifoPool::new);
@@ -315,7 +315,7 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
      * {@link Pool#acquire()} {@link Mono Mono}, serving the oldest pending acquire first
      * whenever a resource becomes available.
      *
-     * @return a builder of {@link Pool} with FIFO pending acquire ordering.
+     * @return a builder of {@link Pool} with FIFO pending acquire ordering
      */
     public InstrumentedPool<T> fifo() {
         return build(SimpleFifoPool::new);

--- a/src/main/java/reactor/pool/PoolMetricsRecorder.java
+++ b/src/main/java/reactor/pool/PoolMetricsRecorder.java
@@ -56,14 +56,14 @@ public interface PoolMetricsRecorder {
 	void recordRecycled();
 
 	/**
-	 * Record the number of milliseconds a pooled object has been live (ie. time between allocation and destruction).
-	 * @param millisecondsSinceAllocation the number of milliseconds since the object was allocated, at the time is is destroyed
+	 * Record the number of milliseconds a pooled object has been live (ie time between allocation and destruction).
+	 * @param millisecondsSinceAllocation the number of milliseconds since the object was allocated, at the time it is destroyed
 	 */
 	void recordLifetimeDuration(long millisecondsSinceAllocation);
 
 	/**
 	 * Record the number of milliseconds an object had been idle when it gets pulled from the pool and passed to a borrower.
-	 * @param millisecondsIdle the number of milliseconds an object that was just acquired had previously been idle.
+	 * @param millisecondsIdle the number of milliseconds an object that was just acquired had previously been idle
 	 */
 	void recordIdleTime(long millisecondsIdle);
 

--- a/src/main/java/reactor/pool/PooledRef.java
+++ b/src/main/java/reactor/pool/PooledRef.java
@@ -70,7 +70,7 @@ public interface PooledRef<POOLABLE> {
      * are NO-OP).
      *
      * @return a {@link Mono} that will complete empty when the object has been released. In case of an error the object
-     * is always discarded.
+     * is always discarded
      */
     Mono<Void> release();
 


### PR DESCRIPTION
Standardize on not ending param and return descriptions with
a period and fix one little typo in metric docs.