### PR TITLE
fix #89 Expose timestamps for allocation/release on PooledRefMetadata 

### DIFF
--- a/src/main/java/reactor/pool/PooledRefMetadata.java
+++ b/src/main/java/reactor/pool/PooledRefMetadata.java
@@ -68,4 +68,24 @@ public interface PooledRefMetadata {
 	 * @return the wall-clock age (time since allocation) of the underlying object in milliseconds
 	 */
 	long lifeTime();
+
+	/**
+	 * Return a timestamp that denotes the order in which the {@link PooledRef} was last released,
+	 * or an equivalently totally-ordered positive number that can be used to compare in which order
+	 * two references have been released (unless released within the same millisecond).
+	 * If the {@link PooledRef} is currently acquired and held outside the pool, returns {@literal zero}
+	 * instead.
+	 *
+	 * @return the last release timestamp, or {@literal zero} if currently acquired
+	 */
+	long releaseTimestamp();
+
+	/**
+	 * Return a timestamp that denotes the order in which the {@link PooledRef} was created/allocated,
+	 * or an equivalently totally-ordered positive number that can be used to compare in which order
+	 * two references have been created (unless created within the same millisecond).
+	 *
+	 * @return the creation timestamp
+	 */
+	long allocationTimestamp();
 }

--- a/src/test/java/reactor/pool/AbstractPoolRefTest.java
+++ b/src/test/java/reactor/pool/AbstractPoolRefTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2018-Present Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool;
+
+import java.time.Clock;
+import java.time.Instant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AbstractPoolRefTest {
+
+	private static final class NaiveRef<T> extends AbstractPool.AbstractPooledRef<T> {
+
+		NaiveRef(T poolable, PoolMetricsRecorder metricsRecorder, Clock clock) {
+			super(poolable, metricsRecorder, clock);
+		}
+
+		NaiveRef(AbstractPool.AbstractPooledRef<T> oldRef) {
+			super(oldRef);
+		}
+
+		@Override
+		public Mono<Void> release() {
+			return Mono.empty();
+		}
+
+		@Override
+		public Mono<Void> invalidate() {
+			return Mono.empty();
+		}
+	}
+
+	protected TestUtils.VirtualClock clock;
+	protected TestUtils.InMemoryPoolMetrics poolMetrics;
+
+	@BeforeEach
+	void init() {
+		//we need to differentiate with 0 sometimes
+		clock = new TestUtils.VirtualClock(Instant.ofEpochMilli(1));
+		poolMetrics = new TestUtils.InMemoryPoolMetrics(clock);
+	}
+
+	@Test
+	void initialTimestamps() {
+		NaiveRef<String> ref = new NaiveRef<>("foo", poolMetrics, clock);
+
+		assertThat(ref.allocationTimestamp()).as("allocation timestamp").isOne();
+		assertThat(ref.releaseTimestamp()).as("release timestamp").isOne();
+	}
+
+	@Test
+	void releaseTimestampWhenAcquired() {
+		NaiveRef<String> ref = new NaiveRef<>("foo", poolMetrics, clock);
+
+		clock.setTimeTo(10);
+		ref.markAcquired();
+		clock.setTimeTo(15);
+
+		assertThat(ref.allocationTimestamp()).as("allocation timestamp").isOne();
+		assertThat(ref.releaseTimestamp()).as("release timestamp").isZero();
+		assertThat(ref.idleTime()).as("idle time").isZero();
+	}
+
+	@Test
+	void releaseTimestampWhenNeverAcquired() {
+		NaiveRef<String> ref = new NaiveRef<>("foo", poolMetrics, clock);
+		clock.setTimeTo(15);
+
+		assertThat(ref.allocationTimestamp()).as("allocation timestamp").isOne();
+		assertThat(ref.releaseTimestamp()).as("release timestamp").isOne();
+		assertThat(ref.idleTime()).as("idleTime vs lifeTime").isSameAs(ref.lifeTime());
+	}
+
+	@Test
+	void releaseTimeTracking() {
+		NaiveRef<String> ref = new NaiveRef<>("foo", poolMetrics, clock);
+		ref.markAcquired();
+		clock.setTimeTo(10);
+		ref.markReleased();
+		clock.setTimeTo(15);
+
+		assertThat(ref.allocationTimestamp()).as("allocation timestamp").isOne();
+		assertThat(ref.releaseTimestamp()).as("release timestamp").isEqualTo(10);
+		assertThat(ref.idleTime()).as("idle time").isEqualTo(5); //clock now at 15, released at 10
+	}
+
+}

--- a/src/test/java/reactor/pool/CommonPoolTest.java
+++ b/src/test/java/reactor/pool/CommonPoolTest.java
@@ -18,6 +18,7 @@ package reactor.pool;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1477,7 +1478,7 @@ public class CommonPoolTest {
 
 	@BeforeEach
 	void initRecorder() {
-		this.recorder = new TestUtils.InMemoryPoolMetrics();
+		this.recorder = new TestUtils.InMemoryPoolMetrics(new TestUtils.NanoTimeClock());
 	}
 
 	@ParameterizedTest
@@ -1498,7 +1499,7 @@ public class CommonPoolTest {
 				}))
 				.sizeBetween(10, Integer.MAX_VALUE)
 				.metricsRecorder(recorder)
-				.clock(recorder);
+				.clock(recorder.getClock());
 		AbstractPool<String> pool = configAdjuster.apply(builder);
 
 		assertThatIllegalStateException()
@@ -1530,7 +1531,7 @@ public class CommonPoolTest {
 					}
 				}))
 				.metricsRecorder(recorder)
-				.clock(recorder);
+				.clock(recorder.getClock());
 		Pool<String> pool = configAdjuster.apply(builder);
 
 		pool.acquire().block(); //success
@@ -1574,7 +1575,7 @@ public class CommonPoolTest {
 				}))
 				.sizeBetween(10, Integer.MAX_VALUE)
 				.metricsRecorder(recorder)
-				.clock(recorder);
+				.clock(recorder.getClock());
 		AbstractPool<String> pool = configAdjuster.apply(builder);
 
 		assertThatIllegalStateException()
@@ -1606,7 +1607,7 @@ public class CommonPoolTest {
 					}
 				}))
 				.metricsRecorder(recorder)
-				.clock(recorder);
+				.clock(recorder.getClock());
 		Pool<String> pool = configAdjuster.apply(builder);
 
 		pool.acquire().block(); //success
@@ -1646,7 +1647,7 @@ public class CommonPoolTest {
 					}
 				})
 				.metricsRecorder(recorder)
-				.clock(recorder);
+				.clock(recorder.getClock());
 		Pool<String> pool = configAdjuster.apply(builder);
 
 		pool.acquire().flatMap(PooledRef::release).block();
@@ -1683,7 +1684,7 @@ public class CommonPoolTest {
 					}
 				})
 				.metricsRecorder(recorder)
-				.clock(recorder);
+				.clock(recorder.getClock());
 		Pool<String> pool = configAdjuster.apply(builder);
 
 		pool.acquire().flatMap(PooledRef::release).block();
@@ -1713,7 +1714,7 @@ public class CommonPoolTest {
 				.from(Mono.fromCallable(() -> content.getAndSet("bar")))
 				.evictionPredicate((poolable, metadata) -> "foo".equals(poolable))
 				.metricsRecorder(recorder)
-				.clock(recorder);
+				.clock(recorder.getClock());
 		Pool<String> pool = configAdjuster.apply(builder);
 
 		pool.acquire().flatMap(PooledRef::release).block();
@@ -1737,7 +1738,7 @@ public class CommonPoolTest {
 				.evictionPredicate((poolable, metadata) -> metadata.acquireCount() >= 2)
 				.destroyHandler(i -> Mono.fromRunnable(destroyCounter::incrementAndGet))
 				.metricsRecorder(recorder)
-				.clock(recorder);
+				.clock(recorder.getClock());
 		Pool<Integer> pool = configAdjuster.apply(builder);
 
 		//first round
@@ -1774,7 +1775,7 @@ public class CommonPoolTest {
 				.from(Mono.fromCallable(allocCounter::incrementAndGet))
 				.sizeBetween(2, 2)
 				.metricsRecorder(recorder)
-				.clock(recorder);
+				.clock(recorder.getClock());
 		Pool<Integer> pool = configAdjuster.apply(builder);
 		pool.warmup().block();
 
@@ -1805,7 +1806,7 @@ public class CommonPoolTest {
 				.from(Mono.fromCallable(allocCounter::incrementAndGet))
 				.sizeBetween(2, 2)
 				.metricsRecorder(recorder)
-				.clock(recorder);
+				.clock(recorder.getClock());
 		Pool<Integer> pool = configAdjuster.apply(builder);
 		pool.warmup().block();
 

--- a/src/test/java/reactor/pool/TestUtils.java
+++ b/src/test/java/reactor/pool/TestUtils.java
@@ -83,6 +83,16 @@ public class TestUtils {
         public long idleTime() {
             return msSinceRelease;
         }
+
+        @Override
+        public long allocationTimestamp() {
+            return 0;
+        }
+
+        @Override
+        public long releaseTimestamp() {
+            return msSinceAllocation - msSinceRelease;
+        }
     }
 
     public static final class PoolableTest implements Disposable {


### PR DESCRIPTION
Also [Polish] Split Clock out of InMemoryPoolMetrics, add 2 test Clocks

