### PR TITLE
Add SamplingAllocationStrategy, in new introspection util package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,6 +179,7 @@ configure(rootProject) { project ->
     testImplementation "io.projectreactor:reactor-test:$reactorCoreVersion"
     testRuntimeOnly "org.slf4j:jcl-over-slf4j:$slf4jVersion"
     testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
 
     testImplementation "io.reactivex.rxjava2:rxjava:$rxJava2Version"
 

--- a/src/main/java/reactor/pool/introspection/SamplingAllocationStrategy.java
+++ b/src/main/java/reactor/pool/introspection/SamplingAllocationStrategy.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2018-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool.introspection;
+
+import java.util.BitSet;
+import java.util.LinkedList;
+import java.util.Objects;
+import java.util.Random;
+
+import reactor.core.Exceptions;
+import reactor.core.publisher.Mono;
+import reactor.pool.AllocationStrategy;
+import reactor.pool.PoolBuilder;
+
+/**
+ * An {@link AllocationStrategy} that delegates to an underlying {@link AllocationStrategy} and samples
+ * the {@link #getPermits(int)} and {@link #returnPermits(int)} methods.
+ * <p>
+ * Only a given percentage of calls are sampled, and these are stored as stacktraces in the sampling strategy.
+ * If a {@link AllocationStrategy#returnPermits(int)} call fails, a new {@link IllegalArgumentException}
+ * is thrown with a composite cause that represents all the sampled calls (see {@link Exceptions#unwrapMultiple(Throwable)}).
+ * <p>
+ * The two types of calls are sampled separately. The reservoir sampling algorithm is used to instantiate a sampling decision
+ * bitset over 100 slots, which are then applied to windows of 100 calls.
+ *
+ * @author Simon Baslé
+ */
+public final class SamplingAllocationStrategy implements AllocationStrategy {
+
+	//TODO replace with a more direct call to the standard strategy in case we make something public, eg. AllocationStrategies factory methods
+	static AllocationStrategy sizeBetweenHelper(int min, int max) {
+		AllocationStrategy[] as = new AllocationStrategy[1];
+		PoolBuilder.from(Mono.empty())
+		           .sizeBetween(min, max)
+		           .build(config -> {
+			           as[0] = config.allocationStrategy();
+			           return null;
+		           });
+		return as[0];
+	}
+
+	/**
+	 * An {@link SamplingAllocationStrategy} that wraps a {@link PoolBuilder#sizeBetween(int, int) sizeBetween} {@link AllocationStrategy}
+	 * and samples calls to {@link AllocationStrategy#getPermits(int)} and {@link AllocationStrategy#returnPermits(int)}.
+	 *
+	 * @param min the minimum number of permits (see {@link PoolBuilder#sizeBetween(int, int)})
+	 * @param max the maximum number of permits (see {@link PoolBuilder#sizeBetween(int, int)})
+	 * @param getPermitsSamplingRate the sampling rate for {@link AllocationStrategy#getPermits(int)} calls (0.0d to 1.0d)
+	 * @param returnPermitsSamplingRate the sampling rate for {@link AllocationStrategy#returnPermits(int)} calls (0.0d to 1.0d)
+	 * @return a sampled {@link AllocationStrategy} that otherwise behaves like the {@link PoolBuilder#sizeBetween(int, int)} strategy
+	 */
+	public static AllocationStrategy sizeBetweenWithSampling(int min, int max, double getPermitsSamplingRate, double returnPermitsSamplingRate) {
+		return new SamplingAllocationStrategy(sizeBetweenHelper(min, max), getPermitsSamplingRate, returnPermitsSamplingRate);
+	}
+
+	/**
+	 * An {@link AllocationStrategy} that wraps a {@code delegate} and samples calls to {@link AllocationStrategy#getPermits(int)}
+	 * and {@link AllocationStrategy#returnPermits(int)}. Only a given percentage of calls are sampled, and these are stored as stacktraces
+	 * in the sampling strategy. If a {@link AllocationStrategy#returnPermits(int)} call fails, a new {@link IllegalArgumentException}
+	 * is thrown with a composite cause that represents all the sampled calls (see {@link Exceptions#unwrapMultiple(Throwable)}).
+	 * <p>
+	 * The two types of calls are sampled separately. The reservoir sampling algorithm is used to instantiate a sampling decision
+	 * bitset over 100 slots, which are then applied live to windows of 100 calls.
+	 *
+	 * @param delegate the underlying {@link AllocationStrategy}
+	 * @param getPermitsSamplingRate the sampling rate for {@link AllocationStrategy#getPermits(int)} calls (0.0d to 1.0d)
+	 * @param returnPermitsSamplingRate the sampling rate for {@link AllocationStrategy#returnPermits(int)} calls (0.0d to 1.0d)
+	 * @return a sampled {@link AllocationStrategy} that otherwise behaves like the {@code delegate}
+	 */
+	public static AllocationStrategy withSampling(AllocationStrategy delegate, double getPermitsSamplingRate, double returnPermitsSamplingRate) {
+		return new SamplingAllocationStrategy(delegate, getPermitsSamplingRate, returnPermitsSamplingRate);
+	}
+
+	final AllocationStrategy    delegate;
+
+	final LinkedList<Throwable> gettingSamples;
+	final double                gettingSamplingRate;
+	final BitSet                gettingSampleDecisions;
+
+	final LinkedList<Throwable> returningSamples;
+	final double                returningSamplingRate;
+	final BitSet                returningSampleDecisions;
+
+	long countGetting   = 0L;
+	long countReturning = 0L;
+
+	SamplingAllocationStrategy(AllocationStrategy delegate, double gettingSamplingRate, double returningSamplingRate) {
+		if (gettingSamplingRate < 0d || gettingSamplingRate > 1d) {
+			throw new IllegalArgumentException("gettingSamplingRate must be between 0d and 1d (percentage)");
+		}
+		if (returningSamplingRate < 0d || returningSamplingRate > 1d) {
+			throw new IllegalArgumentException("returningSamplingRate must be between 0d and 1d (percentage)");
+		}
+		this.delegate = Objects.requireNonNull(delegate, "delegate");
+
+		this.gettingSamples = new LinkedList<>();
+		this.gettingSamplingRate = gettingSamplingRate;
+		int percentOfGetting = (int) (this.gettingSamplingRate * 100.0d); //constrained between 0 and 1, percentage
+		this.gettingSampleDecisions = sampleBitSet(percentOfGetting);
+
+		this.returningSamples = new LinkedList<>();
+		this.returningSamplingRate = returningSamplingRate;
+		int percentOfReturning = (int) (this.returningSamplingRate * 100.0d); //constrained between 0 and 1, percentage
+		this.returningSampleDecisions = sampleBitSet(percentOfReturning);
+	}
+
+	/**
+	 * Reservoir sampling algorithm borrowed from Stack Overflow.
+	 * https://stackoverflow.com/questions/12817946/generate-a-random-bitset-with-n-1s
+	 *
+	 * @param selectedOutOf100 cardinality of the bit set
+	 * @return a random bitset
+	 */
+	static BitSet sampleBitSet(int selectedOutOf100) {
+		int size = 100;
+		Random rnd = new Random();
+		BitSet result = new BitSet(size);
+		int[] chosen = new int[selectedOutOf100];
+		int i;
+		for (i = 0; i < selectedOutOf100; ++i) {
+			chosen[i] = i;
+			result.set(i);
+		}
+		for (; i < size; ++i) {
+			int j = rnd.nextInt(i + 1);
+			if (j < selectedOutOf100) {
+				result.clear(chosen[j]);
+				result.set(i);
+				chosen[j] = i;
+			}
+		}
+		return result;
+	}
+
+	void sampleGetting(final int desired) {
+		if (gettingSamplingRate == 0d) {
+			return;
+		}
+		long c = countGetting++;
+		boolean doSample;
+		if (gettingSamplingRate == 1d) {
+			doSample = true;
+		}
+		else {
+			long cMod = c % 100L;
+			doSample = gettingSampleDecisions.get((int) cMod);
+		}
+
+		if (doSample) {
+			synchronized (gettingSamples) {
+				gettingSamples.add(new RuntimeException("sample #" + c + ", getPermits(" + desired + ")"));
+			}
+		}
+	}
+
+	void sampleReturning(final int returned) {
+		if (returningSamplingRate == 0d) {
+			return;
+		}
+		long c = countReturning++;
+		boolean doSample;
+		if (returningSamplingRate == 1d) {
+			doSample = true;
+		}
+		else {
+			long cMod = c % 100L;
+			doSample = returningSampleDecisions.get((int) cMod);
+		}
+
+		if (doSample) {
+			synchronized (gettingSamples) {
+				returningSamples.add(new RuntimeException("sample #" + c + ", returnPermits(" + returned +") while granted=" + permitGranted()));
+			}
+		}
+	}
+
+	@Override
+	public int getPermits(int desired) {
+		sampleGetting(desired);
+		return delegate.getPermits(desired);
+	}
+
+	@Override
+	public void returnPermits(int returned) {
+		try {
+			delegate.returnPermits(returned);
+			//don't sample if the returnPermits failed (the thrown exception will point to the over-returning code path)
+			sampleReturning(returned);
+		}
+		catch (Throwable permitError) {
+			RuntimeException cause = Exceptions.multiple(gettingSamples);
+			throw new IllegalArgumentException(
+					String.format("Return permits failed, see cause for %d getPermits samples (%d%% of %d calls) and %d returnPermits samples (%d%% of %d calls). Reason: %s",
+							this.gettingSamples.size(), (int) (gettingSamplingRate * 100d), this.countGetting,
+							this.returningSamples.size(), (int) (returningSamplingRate * 100d), this.countReturning,
+							permitError.getMessage()),
+					cause);
+		}
+	}
+
+	@Override
+	public int estimatePermitCount() {
+		return delegate.estimatePermitCount();
+	}
+
+	@Override
+	public int permitGranted() {
+		return delegate.permitGranted();
+	}
+
+	@Override
+	public int permitMinimum() {
+		return delegate.permitMinimum();
+	}
+
+	@Override
+	public int permitMaximum() {
+		return delegate.permitMaximum();
+	}
+}

--- a/src/main/java/reactor/pool/introspection/SamplingAllocationStrategy.java
+++ b/src/main/java/reactor/pool/introspection/SamplingAllocationStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/reactor/pool/introspection/SamplingAllocationStrategyTest.java
+++ b/src/test/java/reactor/pool/introspection/SamplingAllocationStrategyTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2018-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool.introspection;
+
+import org.junit.jupiter.api.Test;
+
+import reactor.pool.AllocationStrategy;
+
+import static org.assertj.core.api.Assertions.*;
+
+class SamplingAllocationStrategyTest {
+
+	@Test
+	void delegateNull() {
+		assertThatNullPointerException()
+				.isThrownBy(() -> new SamplingAllocationStrategy(null, 1d, 1d))
+				.withMessage("delegate");
+	}
+
+	@Test
+	void gettingSamplingRateNegative() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new SamplingAllocationStrategy(SamplingAllocationStrategy.sizeBetweenHelper(0, 100),
+						-0.5d, 0.5d))
+				.withMessage("gettingSamplingRate must be between 0d and 1d (percentage)");
+	}
+
+	@Test
+	void gettingSamplingRateZeroDoesNotIncreaseCountOrSampleSize() {
+		SamplingAllocationStrategy strategy = new SamplingAllocationStrategy(SamplingAllocationStrategy.sizeBetweenHelper(0, 100),
+				0.0d, 0.5d);
+
+		for (int i = 0; i < 100; i++) {
+			strategy.getPermits(1);
+		}
+
+		assertThat(strategy.countGetting).isZero();
+		assertThat(strategy.gettingSamples).isEmpty();
+	}
+
+	@Test
+	void gettingSamplingRateFiftyPercent() {
+		SamplingAllocationStrategy strategy = new SamplingAllocationStrategy(SamplingAllocationStrategy.sizeBetweenHelper(0, 100),
+				0.5d, 0.5d);
+
+		for (int i = 0; i < 100; i++) {
+			strategy.getPermits(1);
+		}
+
+		assertThat(strategy.countGetting).isEqualTo(100);
+		assertThat(strategy.gettingSamples.size()).isEqualTo(50);
+	}
+
+	@Test
+	void gettingSamplingRateOne() {
+		SamplingAllocationStrategy strategy = new SamplingAllocationStrategy(SamplingAllocationStrategy.sizeBetweenHelper(0, 100),
+				1.0d, 0.5d);
+
+		for (int i = 0; i < 100; i++) {
+			strategy.getPermits(1);
+		}
+
+		assertThat(strategy.countGetting).isEqualTo(100);
+		assertThat(strategy.gettingSamples).hasSize(100);
+	}
+
+	@Test
+	void gettingSamplingRateAboveOne() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new SamplingAllocationStrategy(SamplingAllocationStrategy.sizeBetweenHelper(0, 100),
+						1.5d, 0.5d))
+				.withMessage("gettingSamplingRate must be between 0d and 1d (percentage)");
+	}
+
+	@Test
+	void returningSamplingRateNegative() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new SamplingAllocationStrategy(SamplingAllocationStrategy.sizeBetweenHelper(0, 100),
+						0.5d, -0.5d))
+				.withMessage("returningSamplingRate must be between 0d and 1d (percentage)");
+	}
+
+	@Test
+	void returningSamplingRateZeroDoesNotIncreaseCountOrSampleSize() {
+		SamplingAllocationStrategy strategy = new SamplingAllocationStrategy(SamplingAllocationStrategy.sizeBetweenHelper(0, 100),
+				0.5d, 0.0d);
+		strategy.getPermits(100); //needed to make returnPermits calls possible
+
+		for (int i = 0; i < 100; i++) {
+			strategy.returnPermits(1);
+		}
+
+		assertThat(strategy.countReturning).isZero();
+		assertThat(strategy.returningSamples).isEmpty();
+	}
+
+	@Test
+	void returningSamplingRateFiftyPercent() {
+		SamplingAllocationStrategy strategy = new SamplingAllocationStrategy(SamplingAllocationStrategy.sizeBetweenHelper(0, 100),
+				0.5d, 0.5d);
+		strategy.getPermits(100); //needed to make returnPermits calls possible
+
+		for (int i = 0; i < 100; i++) {
+			strategy.returnPermits(1);
+		}
+
+		assertThat(strategy.countReturning).isEqualTo(100);
+		assertThat(strategy.returningSamples.size()).isEqualTo(50);
+	}
+
+	@Test
+	void returningSamplingRateOne() {
+		SamplingAllocationStrategy strategy = new SamplingAllocationStrategy(SamplingAllocationStrategy.sizeBetweenHelper(0, 100),
+				0.5d, 1d);
+		strategy.getPermits(100); //needed to make returnPermits calls possible
+
+		for (int i = 0; i < 100; i++) {
+			strategy.returnPermits(1);
+		}
+
+		assertThat(strategy.countReturning).isEqualTo(100);
+		assertThat(strategy.returningSamples).hasSize(100);
+	}
+
+	@Test
+	void returningSamplingRateAboveOne() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new SamplingAllocationStrategy(SamplingAllocationStrategy.sizeBetweenHelper(0, 100),
+						0.5d, 1.5d))
+				.withMessage("returningSamplingRate must be between 0d and 1d (percentage)");
+	}
+
+	@Test
+	void smokeTest() {
+		AllocationStrategy
+				strategy = SamplingAllocationStrategy.sizeBetweenWithSampling(0, 100, 0.5d, 0.1d);
+
+		for (int i = 0; i < 100; i++) {
+			strategy.getPermits(1);
+		}
+		for (int i = 0; i < 100; i++) {
+			strategy.returnPermits(1);
+		}
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> strategy.returnPermits(1))
+				.withMessage("Return permits failed, see cause for 50 getPermits samples (50% of 100 calls) and " +
+						"10 returnPermits samples (10% of 100 calls). Reason: Too many permits returned: " +
+						"returned=1, would bring to 101/100");
+	}
+
+}

--- a/src/test/java/reactor/pool/introspection/SamplingAllocationStrategyTest.java
+++ b/src/test/java/reactor/pool/introspection/SamplingAllocationStrategyTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *        https://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This pull request adds a utility `AllocationStrategy` to trace a sample of calls to `getPermits` and `returnPermits`.

The strategy lives in a newly introduced `introspection` package.