### PR TITLE
Use api dependency for core, ie compile scope in pom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,7 +167,7 @@ configure(rootProject) { project ->
   }
 
   dependencies {
-    implementation "io.projectreactor:reactor-core:$reactorCoreVersion"
+    api "io.projectreactor:reactor-core:$reactorCoreVersion"
 
     // JSR-305 annotations
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"


### PR DESCRIPTION
This is because types from reactor-code leak in the signature of
reactor-pool, so should be marked as API.
As a consequence, the published pom will use compile instead of
runtime.