### PR TITLE
[backport] Remove jcenter from build in 0.1.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,6 @@ configure(rootProject) { project ->
   }
 
   repositories {
-    jcenter()
     mavenCentral()
     maven { url "https://oss.sonatype.org/content/repositories/releases/" }
     if (version.endsWith('BUILD-SNAPSHOT')) {
@@ -221,7 +220,7 @@ task downloadBaseline(type: Download) {
   onlyIfNewer true
   compress true
 
-  src "${repositories.jcenter().url}io/projectreactor/addons/reactor-pool/$compatibleVersion/reactor-pool-${compatibleVersion}.jar"
+  src "${repositories.mavenCentral().url}io/projectreactor/addons/reactor-pool/$compatibleVersion/reactor-pool-${compatibleVersion}.jar"
   dest "${buildDir}/baselineLibs/reactor-pool-${compatibleVersion}.jar"
 }
 


### PR DESCRIPTION
This is a backport of commits a2446d4 and 956a0b2.

See reactor/reactor#695.
