### PR TITLE
Only increment acquiredSize() once resource has been allocated

### DIFF
--- a/src/main/java/reactor/pool/InstrumentedPool.java
+++ b/src/main/java/reactor/pool/InstrumentedPool.java
@@ -40,7 +40,10 @@ public interface InstrumentedPool<POOLABLE> extends Pool<POOLABLE> {
 
 		/**
 		 * Measure the current number of resources that have been successfully
-		 * {@link Pool#acquire() acquired} and are in active use.
+		 * {@link Pool#acquire() acquired} and are in active use, outside of the
+		 * control of the pool until they're released back to it. This number is
+		 * only incremented after the resource has been successfully allocated and
+		 * is about to be handed off to the subscriber of {@link Pool#acquire()}.
 		 *
 		 * @return the number of acquired resources
 		 */

--- a/src/main/java/reactor/pool/SimpleDequePool.java
+++ b/src/main/java/reactor/pool/SimpleDequePool.java
@@ -361,7 +361,6 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 							return;
 						}
 						borrower.stopPendingCountdown();
-						ACQUIRED.incrementAndGet(this);
 						long start = clock.millis();
 						Mono<POOLABLE> allocator = allocatorWithScheduler();
 
@@ -369,6 +368,7 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 							if (sig.isOnNext()) {
 								POOLABLE newInstance = sig.get();
 								assert newInstance != null;
+								ACQUIRED.incrementAndGet(this);
 								metricsRecorder.recordAllocationSuccessAndLatency(clock.millis() - start);
 								borrower.deliver(createSlot(newInstance));
 							}
@@ -376,7 +376,6 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 								Throwable error = sig.getThrowable();
 								assert error != null;
 								metricsRecorder.recordAllocationFailureAndLatency(clock.millis() - start);
-								ACQUIRED.decrementAndGet(this);
 								poolConfig.allocationStrategy()
 								          .returnPermits(1);
 								borrower.fail(error);

--- a/src/test/java/reactor/pool/CommonPoolTest.java
+++ b/src/test/java/reactor/pool/CommonPoolTest.java
@@ -43,7 +43,6 @@ import org.awaitility.Awaitility;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -67,6 +66,7 @@ import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
 
 /**
  * @author Simon Baslé
@@ -2528,5 +2528,35 @@ public class CommonPoolTest {
 		assertThat(ref2.poolable()).as("ref2").isEqualTo(style.isLru ? "2warmup" : "1warmup");
 		assertThat(ref3.poolable()).as("ref3").isEqualTo("3noContext");
 		assertThat(ref4.poolable()).as("ref4").isEqualTo("4noContext");
+	}
+
+	@ParameterizedTestWithName
+	@EnumSource
+	void longAllocationDoesntUpdateAcquired(PoolStyle style) {
+		PoolBuilder<Integer, PoolConfig<Integer>> configBuilder = PoolBuilder
+				.from(Mono.just(1).delayElement(Duration.ofSeconds(1)))
+				.sizeBetween(0, 1);
+
+		InstrumentedPool<Integer> pool = style.apply(configBuilder);
+
+		AtomicBoolean next = new AtomicBoolean();
+		AtomicBoolean error = new AtomicBoolean();
+		AtomicBoolean complete = new AtomicBoolean();
+
+		pool.acquire().subscribe(
+				stringPooledRef -> next.set(true),
+				throwable -> error.set(true),
+				() -> complete.set(true)
+		);
+
+		assertThat(next).as("hasn't received value yet").isFalse();
+		assertThat(pool.metrics().acquiredSize()).as("acquired size before allocator done").isZero();
+
+		Awaitility.await().untilAtomic(complete, is(true));
+
+		assertThat(error).as("error").isFalse();
+		assertThat(next).as("next").isTrue();
+
+		assertThat(pool.metrics().acquiredSize()).as("acquired size after allocator done").isOne();
 	}
 }


### PR DESCRIPTION
This commit ensures the acquiredSize() metric is only updated when the
resource has been allocated, and is about to be handed off to the
subscriber of acquire().

The decrement in case of allocation error is thus not needed anymore.

Fixes #126.
