### PR TITLE
Make log quieter in CommonPoolTest#pendingLimitAsync

### DIFF
--- a/src/test/java/reactor/pool/CommonPoolTest.java
+++ b/src/test/java/reactor/pool/CommonPoolTest.java
@@ -974,7 +974,7 @@ public class CommonPoolTest {
 					    	else otherTerminationCount.incrementAndGet();
 					    })
 					    .doOnError(error::set)
-					    .subscribe()
+					    .subscribe(v -> {}, e -> {})
 			);
 			RaceTestUtils.race(runnable, runnable);
 


### PR DESCRIPTION
The test would log an `ErrorCallbackNotImplemented` but the error is
actually evaluated in a `doOnError`, so we can suppress this output
by subscribing with an empty error handler.

Fixes #125.
