### PR TITLE
Add inactivity insights (secondsSinceLastInteraction)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,10 +174,12 @@ configure(rootProject) { project ->
     testImplementation "org.assertj:assertj-core:$assertJVersion"
     testImplementation "org.awaitility:awaitility:$awaitilityVersion"
     testImplementation "org.hdrhistogram:HdrHistogram:$hdrHistogramVersion"
-    testImplementation "io.projectreactor:reactor-test:$reactorCoreVersion"
     testRuntimeOnly "org.slf4j:jcl-over-slf4j:$slf4jVersion"
     testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
+
+    testImplementation "io.projectreactor:reactor-test:$reactorCoreVersion"
+    testImplementation "io.projectreactor.addons:reactor-extra:$reactorAddonsVersion"
 
     testImplementation "io.reactivex.rxjava2:rxjava:$rxJava2Version"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 version=0.1.11.BUILD-SNAPSHOT
 reactorCoreVersion=3.3.17.BUILD-SNAPSHOT
+reactorAddonsVersion=3.3.7.BUILD-SNAPSHOT
 compatibleVersion=0.1.10.RELEASE

--- a/src/main/java/reactor/pool/SimpleDequePool.java
+++ b/src/main/java/reactor/pool/SimpleDequePool.java
@@ -93,6 +93,7 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 		this.pendingBorrowerFirstInFirstServed = pendingBorrowerFirstInFirstServed;
 		this.pending = new ConcurrentLinkedDeque<>(); //unbounded
 		this.idleResources = new ConcurrentLinkedDeque<>();
+		recordInteractionTimestamp();
 
 		scheduleEviction();
 	}
@@ -136,6 +137,7 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 		if (WIP.getAndIncrement(this) == 0) {
 			@SuppressWarnings("unchecked")
 			ConcurrentLinkedDeque<Borrower<POOLABLE>> borrowers = PENDING.get(this);
+			recordInteractionTimestamp();
 			if (borrowers.size() == 0) {
 				BiPredicate<POOLABLE, PooledRefMetadata> evictionPredicate = poolConfig.evictionPredicate();
 				//only one evictInBackground can enter here, and it won vs `drain` calls
@@ -163,6 +165,8 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 	@Override
 	public Mono<Void> disposeLater() {
 		return Mono.defer(() -> {
+			recordInteractionTimestamp();
+
 			//TODO mark the termination differently and handle Borrower.fail inside drainLoop
 			//TODO also IDLE_RESOURCE
 			//to make it truly MPSC
@@ -207,6 +211,7 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 		if (poolConfig.allocationStrategy()
 		              .permitMinimum() > 0) {
 			return Mono.deferWithContext(ctx -> {
+				recordInteractionTimestamp();
 				int initSize = poolConfig.allocationStrategy()
 				                         .getPermits(0);
 				@SuppressWarnings({ "unchecked", "rawtypes" }) //rawtypes added since javac actually complains
@@ -267,6 +272,8 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 	}
 
 	private void drainLoop() {
+		//we mark the interaction timestamp twice (beginning and end) rather than continuously on each iteration
+		recordInteractionTimestamp();
 		int maxPending = poolConfig.maxPending();
 
 		for (;;) {
@@ -416,6 +423,7 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 			}
 
 			if (WIP.decrementAndGet(this) == 0) {
+				recordInteractionTimestamp();
 				break;
 			}
 		}
@@ -472,6 +480,7 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 	@SuppressWarnings("WeakerAccess")
 	final void maybeRecycleAndDrain(QueuePooledRef<POOLABLE> poolSlot) {
 		if (!isDisposed()) {
+			recordInteractionTimestamp();
 			if (!poolConfig.evictionPredicate()
 			               .test(poolSlot.poolable, poolSlot)) {
 				metricsRecorder.recordRecycled();

--- a/src/test/java/reactor/pool/SimpleDequePoolInstrumentationTest.java
+++ b/src/test/java/reactor/pool/SimpleDequePoolInstrumentationTest.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2018-Present VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.scheduler.clock.SchedulerClock;
+import reactor.test.scheduler.VirtualTimeScheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Simon Baslé
+ */
+class SimpleDequePoolInstrumentationTest {
+
+	@Test
+	void backgroundEvictionMarksInteraction() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				.evictInBackground(Duration.ofSeconds(10), vts)
+				.clock(SchedulerClock.of(vts))
+				.buildConfig(), true);
+
+		assertThat(pool.lastInteractionTimestamp).as("initial timestamp").isZero();
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("initial secondsSinceLastInteraction")
+				.isZero();
+
+		vts.advanceTimeBy(Duration.ofSeconds(5));
+
+		assertThat(pool.lastInteractionTimestamp)
+				.as("pre-eviction timestamp hasn't moved")
+				.isEqualTo(0L);
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("pre-eviction secondsSinceLastInteraction")
+				.isEqualTo(5L);
+
+		vts.advanceTimeBy(Duration.ofSeconds(5));
+
+		assertThat(pool.lastInteractionTimestamp)
+				.as("post-eviction timestamp")
+				.isEqualTo(10_000L);
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("post-eviction secondsSinceLastInteraction")
+				.isZero();
+	}
+
+	@Test
+	void warmupLazilyMarksInteraction() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .sizeBetween(5, 10)
+				           .clock(SchedulerClock.of(vts))
+				           .buildConfig(), true);
+
+		assertThat(pool.lastInteractionTimestamp).as("initial timestamp").isZero();
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("initial secondsSinceLastInteraction")
+				.isZero();
+
+		vts.advanceTimeBy(Duration.ofSeconds(5));
+		Mono<Integer> warmupMono = pool.warmup();
+
+		assertThat(pool.lastInteractionTimestamp)
+				.as("warmupMono timestamp hasn't moved")
+				.isEqualTo(0L);
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("warmupMono secondsSinceLastInteraction")
+				.isEqualTo(5L);
+
+		vts.advanceTimeBy(Duration.ofSeconds(5));
+		warmupMono.block();
+
+		assertThat(pool.lastInteractionTimestamp)
+				.as("subscribed warmupMono timestamp")
+				.isEqualTo(10_000L);
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("subscribed warmupMono secondsSinceLastInteraction")
+				.isZero();
+	}
+
+	@Test
+	void acquireLazilyMarksInteraction() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .clock(SchedulerClock.of(vts))
+				           .buildConfig(), true);
+
+		assertThat(pool.lastInteractionTimestamp).as("initial timestamp").isZero();
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("initial secondsSinceLastInteraction")
+				.isZero();
+
+		vts.advanceTimeBy(Duration.ofSeconds(5));
+		Mono<PooledRef<String>> acquireMono = pool.acquire();
+
+		assertThat(pool.lastInteractionTimestamp)
+				.as("acquireMono timestamp hasn't moved")
+				.isEqualTo(0L);
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("acquireMono secondsSinceLastInteraction")
+				.isEqualTo(5L);
+
+		vts.advanceTimeBy(Duration.ofSeconds(5));
+		acquireMono.block();
+
+		assertThat(pool.lastInteractionTimestamp)
+				.as("subscribed acquireMono timestamp")
+				.isEqualTo(10_000L);
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("subscribed acquireMono secondsSinceLastInteraction")
+				.isZero();
+	}
+
+	@Test
+	void releaseLazilyMarksInteraction() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .clock(SchedulerClock.of(vts))
+				           .buildConfig(), true);
+
+		PooledRef<String> ref = pool.acquire().block();
+		assert ref != null;
+
+		assertThat(pool.lastInteractionTimestamp).as("initial timestamp").isZero();
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("initial secondsSinceLastInteraction")
+				.isZero();
+
+		vts.advanceTimeBy(Duration.ofSeconds(5));
+		Mono<Void> releaseMono = ref.release();
+
+		assertThat(pool.lastInteractionTimestamp)
+				.as("releaseMono timestamp hasn't moved")
+				.isEqualTo(0L);
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("releaseMono secondsSinceLastInteraction")
+				.isEqualTo(5L);
+
+		vts.advanceTimeBy(Duration.ofSeconds(5));
+		releaseMono.block();
+
+		assertThat(pool.lastInteractionTimestamp)
+				.as("subscribed releaseMono timestamp")
+				.isEqualTo(10_000L);
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("subscribed releaseMono secondsSinceLastInteraction")
+				.isZero();
+	}
+
+	@Test
+	void invalidateLazilyMarksInteraction() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .clock(SchedulerClock.of(vts))
+				           .buildConfig(), true);
+
+		PooledRef<String> ref = pool.acquire().block();
+		assert ref != null;
+
+		assertThat(pool.lastInteractionTimestamp).as("initial timestamp").isZero();
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("initial secondsSinceLastInteraction")
+				.isZero();
+
+		vts.advanceTimeBy(Duration.ofSeconds(5));
+		Mono<Void> invalidateMono = ref.invalidate();
+
+		assertThat(pool.lastInteractionTimestamp)
+				.as("invalidateMono timestamp hasn't moved")
+				.isEqualTo(0L);
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("invalidateMono secondsSinceLastInteraction")
+				.isEqualTo(5L);
+
+		vts.advanceTimeBy(Duration.ofSeconds(5));
+		invalidateMono.block();
+
+		assertThat(pool.lastInteractionTimestamp)
+				.as("subscribed invalidateMono timestamp")
+				.isEqualTo(10_000L);
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("subscribed invalidateMono secondsSinceLastInteraction")
+				.isZero();
+	}
+
+	@Test
+	void disposeLaterLazilyMarksInteraction() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .clock(SchedulerClock.of(vts))
+				           .buildConfig(), true);
+
+		assertThat(pool.lastInteractionTimestamp).as("initial timestamp").isZero();
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("initial secondsSinceLastInteraction")
+				.isZero();
+
+		vts.advanceTimeBy(Duration.ofSeconds(5));
+		Mono<Void> disposePoolMono = pool.disposeLater();
+
+		assertThat(pool.lastInteractionTimestamp)
+				.as("disposePoolMono timestamp hasn't moved")
+				.isEqualTo(0L);
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("disposePoolMono secondsSinceLastInteraction")
+				.isEqualTo(5L);
+
+		vts.advanceTimeBy(Duration.ofSeconds(5));
+		disposePoolMono.block();
+
+		assertThat(pool.lastInteractionTimestamp)
+				.as("subscribed disposePoolMono timestamp")
+				.isEqualTo(10_000L);
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("subscribed disposePoolMono secondsSinceLastInteraction")
+				.isZero();
+	}
+
+	@Test
+	void secondsSinceLastInteractionTruncates() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .clock(SchedulerClock.of(vts))
+				           .buildConfig(), true);
+
+		vts.advanceTimeBy(Duration.ofMinutes(3).plusMillis(543));
+
+		assertThat(pool.secondsSinceLastInteraction())
+				.as("duration reported truncated to seconds")
+				.isEqualTo(3 * 60L);
+	}
+
+	@Test
+	void timestampRecordedWithMsPrecision() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .clock(SchedulerClock.of(vts))
+				           .buildConfig(), true);
+
+		vts.advanceTimeBy(Duration.ofMinutes(3).plusMillis(543));
+		pool.recordInteractionTimestamp();
+
+		assertThat(pool.lastInteractionTimestamp)
+				.as("timestamp recorded with ms precision")
+				.isEqualTo(3 * 60 * 1000 + 543);
+	}
+
+	@Test
+	void isInactiveForMoreThanShortCircuitsOnPositiveCounters() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .clock(SchedulerClock.of(vts))
+				           .buildConfig(), true);
+
+		pool.acquire().block();
+
+		vts.advanceTimeBy(Duration.ofMinutes(3).plusMillis(543));
+
+		assertThat(pool.acquiredSize() + pool.idleSize() + pool.pendingAcquireSize() + pool.allocatedSize())
+				.as("smoke test counters > 0")
+				.isPositive();
+
+		assertThat(pool.isInactiveForMoreThan(Duration.ofSeconds(1)))
+				.as("isInactiveForMoreThan(1s)")
+				.isFalse();
+	}
+
+	@Test
+	void isInactiveForMoreThanDoesntTruncateParameter() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .clock(SchedulerClock.of(vts))
+				           .buildConfig(), true);
+
+		vts.advanceTimeBy(Duration.ofMinutes(3).plusMillis(543));
+		pool.recordInteractionTimestamp();
+
+		assertThat(pool.acquiredSize() + pool.idleSize() + pool.pendingAcquireSize() + pool.allocatedSize())
+				.as("smoke test counters == 0")
+				.isZero();
+
+		//if 123ms was truncated to seconds to, we'd get inactive(0s) == duration(0s)
+		assertThat(pool.isInactiveForMoreThan(Duration.ofMillis(123)))
+				.as("isInactiveForMoreThan(123ms)")
+				.isFalse();
+	}
+
+}


### PR DESCRIPTION
This commit adds inactivity insights to the InstrumentedPool interface,
allowing to get a sense of how long a pool has been inactive for.

secondsSinceLastInteraction() returns a long representing the number of
seconds since the last recorded interaction, which currently includes
explicitly background eviction, warmup, maybeRecycleAndDrain, pool
disposeLater and any interaction that ends up executing the drainLoop.

Additionally, isInactiveForMoreThan(Duration) convenience method is
also provided.

Fixes #134.
