### PR TITLE
Introduce decorators, add GracefulShutdown feature as decorator

### DIFF
--- a/src/main/java/reactor/pool/PoolBuilder.java
+++ b/src/main/java/reactor/pool/PoolBuilder.java
@@ -132,7 +132,6 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
 		return this;
 	}
 
-
 	/**
 	 * Provide a {@link Function handler} that will derive a destroy {@link Publisher} whenever a resource isn't fit for
 	 * usage anymore (either through eviction, manual invalidation, or because something went wrong with it).
@@ -419,6 +418,19 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
 	public InstrumentedPool<T> buildPool() {
 		return new SimpleDequePool<>(this.buildConfig(), true);
 	}
+
+	/**
+	 * Construct a default reactor pool with the builder's configuration, then wrap it
+	 * into a decorator implementation using the provided {@link Function}.
+	 *
+	 * @param decorator a decorator {@link Function} returning a decorated version of the {@link InstrumentedPool}
+	 * @param <P> the type of decorated pool, must extend {@link InstrumentedPool} (with same type of resource)
+	 * @return the built-then-decorated pool
+	 */
+	public <P extends InstrumentedPool<T>> P buildPoolAndDecorateWith(Function<? super InstrumentedPool<T>, P> decorator) {
+		return decorator.apply(buildPool());
+	}
+
 
 	/**
 	 * Build a LIFO flavor of {@link Pool}, that is to say a flavor where the last

--- a/src/main/java/reactor/pool/PoolShutdownException.java
+++ b/src/main/java/reactor/pool/PoolShutdownException.java
@@ -28,4 +28,8 @@ public class PoolShutdownException extends RuntimeException {
 		super("Pool has been shut down");
 	}
 
+	public PoolShutdownException(String reason) {
+		super(reason);
+	}
+
 }

--- a/src/main/java/reactor/pool/decorators/GracefulShutdownInstrumentedPool.java
+++ b/src/main/java/reactor/pool/decorators/GracefulShutdownInstrumentedPool.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/reactor/pool/decorators/GracefulShutdownInstrumentedPool.java
+++ b/src/main/java/reactor/pool/decorators/GracefulShutdownInstrumentedPool.java
@@ -17,8 +17,10 @@
 package reactor.pool.decorators;
 
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -27,9 +29,11 @@ import reactor.core.Disposables;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SignalType;
 import reactor.core.publisher.Sinks;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.pool.InstrumentedPool;
 import reactor.pool.Pool;
+import reactor.pool.PoolConfig;
 import reactor.pool.PoolShutdownException;
 import reactor.pool.PooledRef;
 import reactor.pool.PooledRefMetadata;
@@ -37,10 +41,12 @@ import reactor.util.Logger;
 import reactor.util.Loggers;
 
 /**
- * A decorating {@link InstrumentedPool} that adds the capacity to  {@link #gracefulShutdown(Duration) gracefully shut down} the pool.
- * Apply to any {@link InstrumentedPool} via the {@link #decorate(InstrumentedPool)} factory method.
+ * A decorating {@link InstrumentedPool} that adds the capacity to  {@link #disposeGracefully(Duration) gracefully shut down} the pool.
+ * Apply to any {@link InstrumentedPool} via the {@link InstrumentedPoolDecorators#gracefulShutdown(InstrumentedPool)}
+ * factory method.
  * <p>
- * Adds the {@link #getOriginalPool()}, {@link #gracefulShutdown(Duration)}, {@link #isGracefullyShuttingDown()} and {@link #isInGracePeriod()} methods.
+ * Adds the {@link #getOriginalPool()}, {@link #disposeGracefully(Duration)}, {@link #isGracefullyShuttingDown()}
+ * and {@link #isInGracePeriod()} methods.
  *
  * @author Simon Baslé
  */
@@ -48,20 +54,16 @@ public final class GracefulShutdownInstrumentedPool<T> implements InstrumentedPo
 
 	private static final Logger LOGGER = Loggers.getLogger(GracefulShutdownInstrumentedPool.class);
 
-	public static <T> GracefulShutdownInstrumentedPool<T> decorate(InstrumentedPool<T> originalPool) {
-		return new GracefulShutdownInstrumentedPool<>(originalPool);
-	}
+	final AtomicLong          acquireTracker;
+	final AtomicInteger       isGracefulShutdown;
+	final Sinks.Empty<Void>   gracefulNotifier;
+	final InstrumentedPool<T> originalPool;
+	final Scheduler           timeoutScheduler;
 
-	private final InstrumentedPool<T> originalPool;
-	private final AtomicLong          acquireTracker;
-	private final AtomicInteger       isGracefulShutdown;
-
-	private final Sinks.Empty<Void> gracefulNotifier;
-
-	private Disposable timeout;
+	Disposable timeout;
 
 	GracefulShutdownInstrumentedPool(InstrumentedPool<T> originalPool) {
-		this.originalPool = originalPool;
+		this.originalPool = Objects.requireNonNull(originalPool, "originalPool");
 		this.acquireTracker = new AtomicLong();
 		this.isGracefulShutdown = new AtomicInteger();
 		this.gracefulNotifier = Sinks.empty();
@@ -69,11 +71,28 @@ public final class GracefulShutdownInstrumentedPool<T> implements InstrumentedPo
 		//worst case scenario, if releases end up disposing this one instead of the real timeout one,
 		//then the CAS inside the timeout task will prevent double shutdown anyway.
 		this.timeout = Disposables.single();
+
+		Scheduler forTimeout;
+		try {
+			forTimeout = originalPool.config().evictInBackgroundScheduler();
+			//detect the default backgroundEvictionScheduler, use another one for timeout
+			if (forTimeout == Schedulers.immediate()) {
+				forTimeout = Schedulers.parallel();
+			}
+		}
+		catch (UnsupportedOperationException uoe) {
+			//the underlying pool hasn't implemented #config() it seems
+			forTimeout = Schedulers.parallel();
+		}
+		this.timeoutScheduler = forTimeout;
 	}
 
 	/**
-	 * Return the original pool.
-	 * @return the original {@link InstrumentedPool}
+	 * Return the original pool. Note that in order for this decorator to work correctly,
+	 * the original pool MUST NOT be used in conjunction with the decorated pool, so
+	 * use this method carefully.
+	 *
+	 * @return the original decorated {@link InstrumentedPool}
 	 */
 	public InstrumentedPool<T> getOriginalPool() {
 		return this.originalPool;
@@ -141,6 +160,10 @@ public final class GracefulShutdownInstrumentedPool<T> implements InstrumentedPo
 	 * Note that the rejection of new acquires and the grace timer start immediately, irrespective of subscription to the
 	 * returned {@link Mono}. Subsequent calls return the same {@link Mono}, effectively getting notifications from the first graceful shutdown
 	 * call and ignoring subsequently provided timeouts.
+	 * <p>
+	 * The timeout runs on the original pool's {@link PoolConfig#evictInBackgroundScheduler()} if it set
+	 * (and provided the pool correctly exposes its configuration via {@link Pool#config()}).
+	 * Otherwise it uses the {@link Schedulers#parallel() parallel Scheduler} as a fallback.
 	 *
 	 * @param gracefulTimeout the maximum {@link Duration} for graceful shutdown before full shutdown is forced (resolution: ms)
 	 *
@@ -148,34 +171,46 @@ public final class GracefulShutdownInstrumentedPool<T> implements InstrumentedPo
 	 *
 	 * @see #disposeLater()
 	 */
-	public Mono<Void> gracefulShutdown(final Duration gracefulTimeout) {
+	public Mono<Void> disposeGracefully(final Duration gracefulTimeout) {
 		if (isGracefulShutdown.compareAndSet(0, 1)) {
+			//first check if the pool is already idle
+			if (acquireTracker.get() == 0 && isGracefulShutdown.compareAndSet(1, 2)) {
+				originalPool
+					.disposeLater()
+					.doFinally(st -> {
+						//emitResult ignored on purpose: only interesting case is terminated. let the other one win
+						gracefulNotifier.tryEmitEmpty();
+					})
+					.subscribe(v -> { }, shutdownError -> LOGGER.warn("Error during the actual shutdown on idle pool", shutdownError));
+
+				return gracefulNotifier.asMono();
+			}
+
 			//implement a timer that will trigger if not all released within the provided Duration
-			timeout = Schedulers.boundedElastic()
-				.schedule(() -> {
-						if (isGracefulShutdown.compareAndSet(1, 2)) {
-							//pending acquires haven't yet all been released, timing out
-							originalPool
-								.disposeLater()
-								.subscribeOn(Schedulers.boundedElastic())
-								.doFinally(st -> gracefulNotifier.emitError(
-									new TimeoutException("Pool has forcefully shut down after graceful timeout of " + gracefulTimeout),
-									Sinks.EmitFailureHandler.FAIL_FAST))
-								.subscribe(v -> {
-									},
-									timedOutError -> LOGGER.warn("Error during the graceful shutdown upon graceful timeout", timedOutError));
-						}
-					},
-					gracefulTimeout.toMillis(),
-					TimeUnit.MILLISECONDS
-				);
+			timeout = timeoutScheduler.schedule(() -> {
+					if (isGracefulShutdown.compareAndSet(1, 2)) {
+						//pending acquires haven't yet all been released, timing out
+						originalPool
+							.disposeLater()
+							.doFinally(st -> {
+								TimeoutException timeoutError = new TimeoutException("Pool has forcefully shut down after graceful timeout of " + gracefulTimeout);
+								Sinks.EmitResult emitResult = gracefulNotifier.tryEmitError(timeoutError);
+								//ignored on purpose: only interesting case is terminated. let the other one win
+							})
+							.subscribe(v -> { },
+								timedOutError -> LOGGER.warn("Error during the graceful shutdown upon graceful timeout", timedOutError));
+					}
+				},
+				gracefulTimeout.toMillis(),
+				TimeUnit.MILLISECONDS
+			);
 			//from there on, acquire() calls will get rejected
 		}
 		return gracefulNotifier.asMono();
 	}
 
 	/**
-	 * Check if the {@link #gracefulShutdown(Duration)} has been invoked.
+	 * Check if the {@link #disposeGracefully(Duration)} has been invoked.
 	 *
 	 * @return true if the pool is in the process of shutting down gracefully, or has already done so
 	 */
@@ -184,7 +219,7 @@ public final class GracefulShutdownInstrumentedPool<T> implements InstrumentedPo
 	}
 
 	/**
-	 * Check if the {@link #gracefulShutdown(Duration)} has been invoked but there are still
+	 * Check if the {@link #disposeGracefully(Duration)} has been invoked but there are still
 	 * pending acquire and the grace period hasn't timed out.
 	 * <p>
 	 * If {@link #isGracefullyShuttingDown()} returns true but this method returns false,
@@ -213,6 +248,11 @@ public final class GracefulShutdownInstrumentedPool<T> implements InstrumentedPo
 	}
 
 	@Override
+	public PoolConfig<T> config() {
+		return originalPool.config();
+	}
+
+	@Override
 	public Mono<Integer> warmup() {
 		return originalPool.warmup();
 	}
@@ -222,8 +262,12 @@ public final class GracefulShutdownInstrumentedPool<T> implements InstrumentedPo
 		return originalPool.disposeLater();
 	}
 
+	@Override
+	public boolean isDisposed() {
+		return originalPool.isDisposed();
+	}
 
-	private class GracefulRef implements PooledRef<T> {
+	final class GracefulRef extends AtomicBoolean implements PooledRef<T> {
 
 		final PooledRef<T> originalRef;
 
@@ -243,35 +287,41 @@ public final class GracefulShutdownInstrumentedPool<T> implements InstrumentedPo
 
 		@Override
 		public Mono<Void> invalidate() {
+			if (get()) {
+				return Mono.empty();
+			}
 			return Mono.defer(() -> {
-				long remaining = acquireTracker.decrementAndGet();
-				if (remaining > 0) {
-					return originalRef.invalidate();
+				if (compareAndSet(false, true)) {
+					long remaining = acquireTracker.decrementAndGet();
+					if (remaining > 0) {
+						return originalRef.invalidate();
+					}
+					else if (remaining == 0) {
+						return originalRef.invalidate()
+							.then(Mono.defer(GracefulShutdownInstrumentedPool.this::tryGracefulDone));
+					}
 				}
-				else if (remaining == 0) {
-					return originalRef.invalidate()
-						.then(Mono.defer(GracefulShutdownInstrumentedPool.this::tryGracefulDone));
-				}
-				else {
-					return Mono.empty();
-				}
+				return Mono.empty();
 			});
 		}
 
 		@Override
 		public Mono<Void> release() {
+			if (get()) {
+				return Mono.empty();
+			}
 			return Mono.defer(() -> {
-				long remaining = acquireTracker.decrementAndGet();
-				if (remaining > 0) {
-					return originalRef.release();
+				if (compareAndSet(false, true)) {
+					long remaining = acquireTracker.decrementAndGet();
+					if (remaining > 0) {
+						return originalRef.release();
+					}
+					else if (remaining == 0) {
+						return originalRef.release()
+							.then(Mono.defer(GracefulShutdownInstrumentedPool.this::tryGracefulDone));
+					}
 				}
-				else if (remaining == 0) {
-					return originalRef.release()
-						.then(Mono.defer(GracefulShutdownInstrumentedPool.this::tryGracefulDone));
-				}
-				else {
-					return Mono.empty();
-				}
+				return Mono.empty();
 			});
 		}
 	}

--- a/src/main/java/reactor/pool/decorators/GracefulShutdownInstrumentedPool.java
+++ b/src/main/java/reactor/pool/decorators/GracefulShutdownInstrumentedPool.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool.decorators;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import reactor.core.Disposable;
+import reactor.core.Disposables;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
+import reactor.core.publisher.Sinks;
+import reactor.core.scheduler.Schedulers;
+import reactor.pool.InstrumentedPool;
+import reactor.pool.Pool;
+import reactor.pool.PoolShutdownException;
+import reactor.pool.PooledRef;
+import reactor.pool.PooledRefMetadata;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+/**
+ * A decorating {@link InstrumentedPool} that adds the capacity to  {@link #gracefulShutdown(Duration) gracefully shut down} the pool.
+ * Apply to any {@link InstrumentedPool} via the {@link #decorate(InstrumentedPool)} factory method.
+ * <p>
+ * Adds the {@link #getOriginalPool()}, {@link #gracefulShutdown(Duration)}, {@link #isGracefullyShuttingDown()} and {@link #isInGracePeriod()} methods.
+ *
+ * @author Simon Baslé
+ */
+public final class GracefulShutdownInstrumentedPool<T> implements InstrumentedPool<T> {
+
+	private static final Logger LOGGER = Loggers.getLogger(GracefulShutdownInstrumentedPool.class);
+
+	public static <T> GracefulShutdownInstrumentedPool<T> decorate(InstrumentedPool<T> originalPool) {
+		return new GracefulShutdownInstrumentedPool<>(originalPool);
+	}
+
+	private final InstrumentedPool<T> originalPool;
+	private final AtomicLong          acquireTracker;
+	private final AtomicInteger       isGracefulShutdown;
+
+	private final Sinks.Empty<Void> gracefulNotifier;
+
+	private Disposable timeout;
+
+	GracefulShutdownInstrumentedPool(InstrumentedPool<T> originalPool) {
+		this.originalPool = originalPool;
+		this.acquireTracker = new AtomicLong();
+		this.isGracefulShutdown = new AtomicInteger();
+		this.gracefulNotifier = Sinks.empty();
+
+		//worst case scenario, if releases end up disposing this one instead of the real timeout one,
+		//then the CAS inside the timeout task will prevent double shutdown anyway.
+		this.timeout = Disposables.single();
+	}
+
+	/**
+	 * Return the original pool.
+	 * @return the original {@link InstrumentedPool}
+	 */
+	public InstrumentedPool<T> getOriginalPool() {
+		return this.originalPool;
+	}
+
+	@Override
+	public Mono<PooledRef<T>> acquire() {
+		if (isGracefulShutdown.get() > 0) {
+			return Mono.error(new PoolShutdownException("The pool is being gracefully shut down and won't accept new acquire calls"));
+		}
+		else {
+			return Mono.defer(() -> {
+				acquireTracker.incrementAndGet();
+				return originalPool
+					.acquire()
+					//accommodate for the fact that the underlying pool might reject the acquire itself, or it could be cancelled
+					.doFinally(st -> {
+						if (st == SignalType.ON_ERROR || st == SignalType.CANCEL) {
+							acquireTracker.decrementAndGet();
+						}
+					})
+					//wrap the PooledRef so that we detect releases
+					.map(GracefulRef::new);
+			});
+		}
+	}
+
+	@Override
+	public Mono<PooledRef<T>> acquire(Duration timeout) {
+		if (isGracefulShutdown.get() > 0) {
+			return Mono.error(new PoolShutdownException("The pool is being gracefully shut down and won't accept new acquire calls"));
+		}
+		else {
+			return Mono.defer(() -> {
+				acquireTracker.incrementAndGet();
+				return originalPool
+					.acquire(timeout)
+					//accommodate for the fact that the underlying pool might reject the acquire itself, or it could be cancelled
+					.doFinally(st -> {
+						if (st == SignalType.ON_ERROR || st == SignalType.CANCEL) {
+							acquireTracker.decrementAndGet();
+						}
+					})
+					//wrap the PooledRef so that we detect releases
+					.map(GracefulRef::new);
+			});
+		}
+	}
+
+	/**
+	 * Trigger a "graceful shutdown" of the pool, with a grace period timeout.
+	 * From there on, calls to {@link Pool#acquire()} and {@link Pool#acquire(Duration)} will
+	 * fail fast with a {@link PoolShutdownException}.
+	 * However, for the provided {@link Duration}, pending acquires will get a chance to be served.
+	 * <p>
+	 * If the wrapper detects that all pending acquires are either {@link PooledRef#release() released}
+	 * or {@link PooledRef#invalidate() invalidated}, the returned {@link Mono} will complete successfully.
+	 * It will do so after having internally called and waited for the original pool's {@link Pool#disposeLater()} method,
+	 * effectively shutting down the pool for good.
+	 * <p>
+	 * If the timeout triggers before that, the returned {@link Mono} will also trigger the {@link Pool#disposeLater()} method,
+	 * but will terminate by emitting a {@link TimeoutException}. Since it means that at that point some pending acquire are
+	 * still registered, these are terminated with a {@link PoolShutdownException} by the {@link #disposeLater()} method.
+	 * <p>
+	 * Note that the rejection of new acquires and the grace timer start immediately, irrespective of subscription to the
+	 * returned {@link Mono}. Subsequent calls return the same {@link Mono}, effectively getting notifications from the first graceful shutdown
+	 * call and ignoring subsequently provided timeouts.
+	 *
+	 * @param gracefulTimeout the maximum {@link Duration} for graceful shutdown before full shutdown is forced (resolution: ms)
+	 *
+	 * @return a {@link Mono} representing the current graceful shutdown of the pool
+	 *
+	 * @see #disposeLater()
+	 */
+	public Mono<Void> gracefulShutdown(final Duration gracefulTimeout) {
+		if (isGracefulShutdown.compareAndSet(0, 1)) {
+			//implement a timer that will trigger if not all released within the provided Duration
+			timeout = Schedulers.boundedElastic()
+				.schedule(() -> {
+						if (isGracefulShutdown.compareAndSet(1, 2)) {
+							//pending acquires haven't yet all been released, timing out
+							originalPool
+								.disposeLater()
+								.subscribeOn(Schedulers.boundedElastic())
+								.doFinally(st -> gracefulNotifier.emitError(
+									new TimeoutException("Pool has forcefully shut down after graceful timeout of " + gracefulTimeout),
+									Sinks.EmitFailureHandler.FAIL_FAST))
+								.subscribe(v -> {
+									},
+									timedOutError -> LOGGER.warn("Error during the graceful shutdown upon graceful timeout", timedOutError));
+						}
+					},
+					gracefulTimeout.toMillis(),
+					TimeUnit.MILLISECONDS
+				);
+			//from there on, acquire() calls will get rejected
+		}
+		return gracefulNotifier.asMono();
+	}
+
+	/**
+	 * Check if the {@link #gracefulShutdown(Duration)} has been invoked.
+	 *
+	 * @return true if the pool is in the process of shutting down gracefully, or has already done so
+	 */
+	public boolean isGracefullyShuttingDown() {
+		return isGracefulShutdown.get() > 0;
+	}
+
+	/**
+	 * Check if the {@link #gracefulShutdown(Duration)} has been invoked but there are still
+	 * pending acquire and the grace period hasn't timed out.
+	 * <p>
+	 * If {@link #isGracefullyShuttingDown()} returns true but this method returns false,
+	 * it means that the pool is now at least in the process of shutting down completely via
+	 * {@link #disposeLater()} (or has already done so).
+	 *
+	 * @return true if the graceful shutdown is still within the grace period, false otherwise
+	 */
+	public boolean isInGracePeriod() {
+		return isGracefulShutdown.get() == 1;
+	}
+
+	private Mono<Void> tryGracefulDone() {
+		if (isGracefulShutdown.compareAndSet(1, 2)) {
+			//the timeout hasn't come into play. cancel it for good measure
+			timeout.dispose();
+			return originalPool.disposeLater()
+				.doFinally(st -> gracefulNotifier.emitEmpty(Sinks.EmitFailureHandler.FAIL_FAST));
+		}
+		return Mono.empty();
+	}
+
+	@Override
+	public PoolMetrics metrics() {
+		return originalPool.metrics();
+	}
+
+	@Override
+	public Mono<Integer> warmup() {
+		return originalPool.warmup();
+	}
+
+	@Override
+	public Mono<Void> disposeLater() {
+		return originalPool.disposeLater();
+	}
+
+
+	private class GracefulRef implements PooledRef<T> {
+
+		final PooledRef<T> originalRef;
+
+		public GracefulRef(PooledRef<T> originalRef) {
+			this.originalRef = originalRef;
+		}
+
+		@Override
+		public T poolable() {
+			return originalRef.poolable();
+		}
+
+		@Override
+		public PooledRefMetadata metadata() {
+			return originalRef.metadata();
+		}
+
+		@Override
+		public Mono<Void> invalidate() {
+			return Mono.defer(() -> {
+				long remaining = acquireTracker.decrementAndGet();
+				if (remaining > 0) {
+					return originalRef.invalidate();
+				}
+				else if (remaining == 0) {
+					return originalRef.invalidate()
+						.then(Mono.defer(GracefulShutdownInstrumentedPool.this::tryGracefulDone));
+				}
+				else {
+					return Mono.empty();
+				}
+			});
+		}
+
+		@Override
+		public Mono<Void> release() {
+			return Mono.defer(() -> {
+				long remaining = acquireTracker.decrementAndGet();
+				if (remaining > 0) {
+					return originalRef.release();
+				}
+				else if (remaining == 0) {
+					return originalRef.release()
+						.then(Mono.defer(GracefulShutdownInstrumentedPool.this::tryGracefulDone));
+				}
+				else {
+					return Mono.empty();
+				}
+			});
+		}
+	}
+}

--- a/src/main/java/reactor/pool/decorators/InstrumentedPoolDecorators.java
+++ b/src/main/java/reactor/pool/decorators/InstrumentedPoolDecorators.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.pool.decorators;
 
 import java.time.Duration;

--- a/src/main/java/reactor/pool/decorators/InstrumentedPoolDecorators.java
+++ b/src/main/java/reactor/pool/decorators/InstrumentedPoolDecorators.java
@@ -1,0 +1,31 @@
+package reactor.pool.decorators;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+import reactor.pool.InstrumentedPool;
+
+/**
+ * Utility class to expose various {@link InstrumentedPool} decorators, which can also be used
+ * via {@link reactor.pool.PoolBuilder#buildPoolAndDecorateWith(Function)}.
+ *
+ * @author Simon Baslé
+ */
+public final class InstrumentedPoolDecorators {
+
+	/**
+	 * Decorate the pool with the capacity to {@link GracefulShutdownInstrumentedPool gracefully shutdown},
+	 * via {@link GracefulShutdownInstrumentedPool#disposeGracefully(Duration)}.
+	 *
+	 * @param pool the original pool
+	 * @param <T> the type of resources in the pool
+	 * @return the decorated pool which can now gracefully shutdown via additional methods
+	 * @see GracefulShutdownInstrumentedPool
+	 */
+	public static <T> GracefulShutdownInstrumentedPool<T> gracefulShutdown(InstrumentedPool<T> pool) {
+		return new GracefulShutdownInstrumentedPool<>(pool);
+	}
+
+	private InstrumentedPoolDecorators() { }
+
+}

--- a/src/test/java/reactor/pool/decorators/GracefulShutdownInstrumentedPoolTest.java
+++ b/src/test/java/reactor/pool/decorators/GracefulShutdownInstrumentedPoolTest.java
@@ -1,0 +1,496 @@
+package reactor.pool.decorators;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.pool.InstrumentedPool;
+import reactor.pool.PoolBuilder;
+import reactor.pool.PoolConfig;
+import reactor.pool.PoolShutdownException;
+import reactor.pool.PooledRef;
+import reactor.pool.decorators.GracefulShutdownInstrumentedPool.GracefulRef;
+import reactor.test.StepVerifier;
+import reactor.test.StepVerifierOptions;
+import reactor.test.scheduler.VirtualTimeScheduler;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.times;
+
+/**
+ * @author Simon Baslé
+ */
+class GracefulShutdownInstrumentedPoolTest {
+
+	@Test
+	void smokeTestDisposeGracefully() {
+		GracefulShutdownInstrumentedPool<String> pool = PoolBuilder.from(Mono.just("foo"))
+			.sizeBetween(0, 5)
+			.buildPoolAndDecorateWith(InstrumentedPoolDecorators::gracefulShutdown);
+
+		PooledRef<String> ref1 = pool.acquire().block();
+
+		pool.disposeGracefully(Duration.ofMinutes(1)).subscribe();
+
+		assertThat(pool.getOriginalPool().isDisposed()).as("original pool isDisposed").isFalse();
+		assertThat(pool.isDisposed()).as("wrapping pool isDisposed").isFalse();
+		assertThat(pool.isGracefullyShuttingDown()).as("wrapping pool isGracefullyShuttingDown").isTrue();
+
+		StepVerifier.create(pool.acquire())
+			.expectErrorMessage("The pool is being gracefully shut down and won't accept new acquire calls")
+			.verify();
+
+		ref1.release().block();
+
+		await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
+				assertThat(pool.getOriginalPool().isDisposed()).as("original pool isDisposed").isTrue();
+				assertThat(pool.isDisposed()).as("wrapping pool isDisposed").isTrue();
+
+			}
+		);
+	}
+
+	@Test
+	void cantInstantiateWithNull() {
+		assertThatNullPointerException().isThrownBy(() -> new GracefulShutdownInstrumentedPool<>(null))
+			.withMessage("originalPool");
+	}
+
+	@Test
+	void canAccessOriginalPool() {
+		InstrumentedPool<String> pool = PoolBuilder.from(Mono.just("foo")).buildPool();
+		GracefulShutdownInstrumentedPool<String> gsPool = InstrumentedPoolDecorators.gracefulShutdown(pool);
+
+		assertThat(gsPool.getOriginalPool()).isSameAs(pool);
+	}
+
+	@Test
+	void poolDelegatedMethods() {
+		PoolConfig<String> config = PoolBuilder.from(Mono.just("foo")).buildPool().config();
+
+		@SuppressWarnings("unchecked") InstrumentedPool<String> pool = Mockito.mock(InstrumentedPool.class);
+		Mockito.when(pool.config()).thenReturn(config);
+
+		GracefulShutdownInstrumentedPool<?> gsPool = InstrumentedPoolDecorators.gracefulShutdown(pool);
+
+		gsPool.metrics();
+		gsPool.config();
+		gsPool.warmup();
+		gsPool.isDisposed();
+		gsPool.disposeLater();
+
+		Mockito.verify(pool).metrics();
+		//config is invoked at construction
+		Mockito.verify(pool, times(2)).config();
+		Mockito.verify(pool).warmup();
+		Mockito.verify(pool).isDisposed();
+		Mockito.verify(pool).disposeLater();
+	}
+
+
+	@Test
+	void poolRefDelegatedMethods() {
+		GracefulShutdownInstrumentedPool<String> gsPool = PoolBuilder.from(Mono.just("foo"))
+			.buildPoolAndDecorateWith(InstrumentedPoolDecorators::gracefulShutdown);
+
+		GracefulRef ref = (GracefulRef) gsPool.acquire().block();
+
+		assertThat(ref.poolable()).as("poolable").isSameAs(ref.originalRef.poolable());
+		assertThat(ref.metadata()).as("metadata").isSameAs(ref.originalRef.metadata());
+	}
+
+	@Test
+	void timeoutSchedulerIsOriginalEvictInBackground() {
+		Scheduler scheduler = Schedulers.newSingle("test");
+		final GracefulShutdownInstrumentedPool<Object> pool =
+			PoolBuilder.from(Mono.empty())
+				.evictInBackground(Duration.ofHours(1), scheduler)
+				.buildPoolAndDecorateWith(InstrumentedPoolDecorators::gracefulShutdown);
+
+		//no need to actually let the scheduler live
+		scheduler.dispose();
+
+		assertThat(pool.timeoutScheduler).isSameAs(scheduler);
+	}
+
+	@Test
+	void timeoutSchedulerDefaultsToParallelIfEvictNotSet() {
+		final GracefulShutdownInstrumentedPool<Object> pool =
+			PoolBuilder.from(Mono.empty())
+				.buildPoolAndDecorateWith(InstrumentedPoolDecorators::gracefulShutdown);
+
+		assertThat(pool.timeoutScheduler)
+			.isSameAs(Schedulers.parallel())
+			.isNotSameAs(pool.config().evictInBackgroundScheduler());
+	}
+
+	@Test
+	void timeoutSchedulerDefaultsToParallelIfConfigInaccessible() {
+		InstrumentedPool<?> pool = new InstrumentedPool<Object>() {
+			@Override
+			public PoolMetrics metrics() {
+				return null;
+			}
+
+			@Override
+			public Mono<Integer> warmup() {
+				return null;
+			}
+
+			@Override
+			public Mono<PooledRef<Object>> acquire() {
+				return null;
+			}
+
+			@Override
+			public Mono<PooledRef<Object>> acquire(Duration timeout) {
+				return null;
+			}
+
+			@Override
+			public Mono<Void> disposeLater() {
+				return null;
+			}
+		};
+
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+			.isThrownBy(pool::config);
+
+		GracefulShutdownInstrumentedPool<?> gsPool = InstrumentedPoolDecorators.gracefulShutdown(pool);
+
+		assertThat(gsPool.timeoutScheduler).isSameAs(Schedulers.parallel());
+	}
+
+	@Test
+	void disposeLaterDirectlyDisposesUnderlyingPool() {
+		InstrumentedPool<String> pool = PoolBuilder.from(Mono.just("foo")).buildPool();
+		GracefulShutdownInstrumentedPool<String> gsPool = InstrumentedPoolDecorators.gracefulShutdown(pool);
+
+		//dispose the pool
+		StepVerifier.create(gsPool.disposeLater()).verifyComplete();
+
+		assertThat(pool.isDisposed()).as("pool isDisposed").isTrue();
+		assertThat(gsPool.isDisposed()).as("gsPool isDisposed").isTrue();
+	}
+
+	@Test
+	void disposeGracefullyIsImmediateIfPoolIdle() {
+		InstrumentedPool<String> pool = PoolBuilder.from(Mono.just("foo")).buildPool();
+		GracefulShutdownInstrumentedPool<String> gsPool = InstrumentedPoolDecorators.gracefulShutdown(pool);
+
+		//dispose the pool with grace period
+		StepVerifier.create(gsPool.disposeGracefully(Duration.ofSeconds(5)))
+			.expectComplete()
+			.verify(Duration.ofMillis(100));
+
+		assertThat(pool.isDisposed()).as("pool isDisposed").isTrue();
+		assertThat(gsPool.isDisposed()).as("gsPool isDisposed").isTrue();
+	}
+
+	@Test
+	void disposeGracefullyTwiceOnIdlePool() {
+		InstrumentedPool<String> pool = PoolBuilder.from(Mono.just("foo")).buildPool();
+		GracefulShutdownInstrumentedPool<String> gsPool = InstrumentedPoolDecorators.gracefulShutdown(pool);
+
+		//dispose the pool with grace period
+		Mono<Void> dispose1 = gsPool.disposeGracefully(Duration.ofSeconds(5));
+		Mono<Void> dispose2 = gsPool.disposeGracefully(Duration.ofSeconds(10));
+
+		StepVerifier.create(dispose1).expectComplete().verify(Duration.ofMillis(200));
+		StepVerifier.create(dispose2).expectComplete().verify(Duration.ofMillis(200));
+
+		assertThat(dispose1).isSameAs(dispose2);
+	}
+
+	@Test
+	void disposeGracefullyTwiceWithActualTimeoutWaitForSameTime() {
+		InstrumentedPool<String> pool = PoolBuilder.from(Mono.just("foo")).buildPool();
+		GracefulShutdownInstrumentedPool<String> gsPool = InstrumentedPoolDecorators.gracefulShutdown(pool);
+
+		//this will cause graceful shutdown to block
+		PooledRef<String> ref1 = gsPool.acquire().block();
+
+		final long[] durations = new long[2];
+		final Mono<?>[] disposeMonos = new Mono[2];
+		//dispose the pool with grace period, twice
+		Schedulers.boundedElastic().schedule(() -> {
+			disposeMonos[0] = gsPool.disposeGracefully(Duration.ofSeconds(5));
+			durations[0] = StepVerifier.create(disposeMonos[0])
+				.verifyError(TimeoutException.class)
+				.toMillis();
+		});
+
+		disposeMonos[1] = gsPool.disposeGracefully(Duration.ofSeconds(2));
+		durations[1] = StepVerifier.create(disposeMonos[1])
+			.verifyError(TimeoutException.class)
+			.toMillis();
+
+		assertThat(disposeMonos[0]).as("same dispose monos").isSameAs(disposeMonos[1]);
+		assertThat(durations[0]).as("similar durations +- 100ms").isCloseTo(durations[1], Offset.offset(100L));
+	}
+
+	@Test
+	void acquireIsFailFastIfShuttingDownGracefully() {
+		InstrumentedPool<String> pool = PoolBuilder.from(Mono.just("foo")).buildPool();
+		GracefulShutdownInstrumentedPool<String> gsPool = InstrumentedPoolDecorators.gracefulShutdown(pool);
+
+		//dispose the pool with grace period. don't wait for the completion as we want to test what happens in the meantime
+		gsPool.disposeGracefully(Duration.ofSeconds(5)).subscribe();
+
+		StepVerifier.create(gsPool.acquire())
+				.verifyErrorSatisfies(e -> assertThat(e)
+					.isInstanceOf(PoolShutdownException.class)
+					.hasMessage("The pool is being gracefully shut down and won't accept new acquire calls"));
+	}
+
+	@Test
+	void acquireTtlIsFailFastIfShuttingDownGracefully() {
+		InstrumentedPool<String> pool = PoolBuilder.from(Mono.just("foo")).buildPool();
+		GracefulShutdownInstrumentedPool<String> gsPool = InstrumentedPoolDecorators.gracefulShutdown(pool);
+
+		//dispose the pool with grace period. don't wait for the completion as we want to test what happens in the meantime
+		gsPool.disposeGracefully(Duration.ofSeconds(5)).subscribe();
+
+		StepVerifier.create(gsPool.acquire(Duration.ofSeconds(5)))
+				.verifyErrorSatisfies(e -> assertThat(e)
+					.isInstanceOf(PoolShutdownException.class)
+					.hasMessage("The pool is being gracefully shut down and won't accept new acquire calls"));
+	}
+
+	@Test
+	void disposeGracefullyTriggersTimeoutIfRefNotReleased() {
+		VirtualTimeScheduler scheduler = VirtualTimeScheduler.create();
+		InstrumentedPool<String> pool = PoolBuilder.from(Mono.just("foo"))
+			.evictInBackground(Duration.ofHours(1), scheduler)
+			.buildPool();
+		GracefulShutdownInstrumentedPool<String> gsPool = InstrumentedPoolDecorators.gracefulShutdown(pool);
+
+		PooledRef<String> ref1 = gsPool.acquire().block();
+
+		StepVerifier.create(gsPool.disposeGracefully(Duration.ofSeconds(20)),
+				StepVerifierOptions.create().virtualTimeSchedulerSupplier(() -> scheduler))
+			.expectSubscription()
+			.thenAwait(Duration.ofSeconds(20))
+			.expectErrorMessage("Pool has forcefully shut down after graceful timeout of PT20S")
+			.verify();
+	}
+
+	@Test
+	void isInGracePeriod() {
+		GracefulShutdownInstrumentedPool<String> gsPool = PoolBuilder.from(Mono.just("foo"))
+			.buildPoolAndDecorateWith(InstrumentedPoolDecorators::gracefulShutdown);
+
+		PooledRef<String> ref = gsPool.acquire().block();
+
+		assertThat(gsPool.isGracefullyShuttingDown()).as("isGracefullyShuttingDown before").isFalse();
+		assertThat(gsPool.isInGracePeriod()).as("isInGracePeriod before").isFalse();
+
+		gsPool.disposeGracefully(Duration.ofMillis(500)).subscribe(v -> {}, e -> {});
+
+		assertThat(gsPool.isGracefullyShuttingDown()).as("isGracefullyShuttingDown during").isTrue();
+		assertThat(gsPool.isInGracePeriod()).as("isInGracePeriod before").isTrue();
+
+		await().atMost(1, TimeUnit.SECONDS)
+			.untilAsserted(() -> {
+				assertThat(gsPool.isGracefullyShuttingDown()).as("isGracefullyShuttingDown after").isTrue();
+				assertThat(gsPool.isInGracePeriod()).as("isInGracePeriod after").isFalse();
+				assertThat(gsPool.isDisposed()).as("isDisposed after").isTrue();
+
+			});
+	}
+
+	void gracefulShutdownTerminatesWhen(BiFunction<Long, PooledRef<Long>, Mono<Void>> refTermination) {
+		AtomicLong source = new AtomicLong();
+		List<PooledRef<Long>> acquired = new ArrayList<>();
+
+		GracefulShutdownInstrumentedPool<Long> gsPool = PoolBuilder.from(Mono.fromSupplier(source::incrementAndGet))
+			.sizeBetween(0, 10)
+			.buildPoolAndDecorateWith(InstrumentedPoolDecorators::gracefulShutdown);
+
+		Flux.range(1, 10)
+			.flatMap(i -> gsPool.acquire())
+			.doOnNext(acquired::add)
+			.blockLast();
+
+		AtomicReference<SignalType> termination = new AtomicReference<>();
+		gsPool.disposeGracefully(Duration.ofSeconds(200))
+			.doFinally(termination::set)
+			.log()
+			.subscribe();
+
+		AtomicInteger refCompleteCount = new AtomicInteger();
+		AtomicInteger refErrorCount = new AtomicInteger();
+
+		for (PooledRef<Long> ref : acquired) {
+			long index = ref.poolable();
+			refTermination.apply(index, ref)
+				.subscribe(v -> {}, e -> refErrorCount.incrementAndGet(), refCompleteCount::incrementAndGet);
+			if (index < 10) {
+				assertThat(gsPool.isInGracePeriod()).as("inGracePeriod during loop #" + index).isTrue();
+			}
+		}
+
+		assertThat(refCompleteCount).as("refCompleteCount").hasValue(10);
+		assertThat(refErrorCount).as("refErrorCount").hasValue(0);
+		assertThat(termination).as("poll disposeGracefully end type").hasValue(SignalType.ON_COMPLETE);
+
+		assertThat(gsPool.isInGracePeriod()).as("inGracePeriod after invalidation/release").isFalse();
+		assertThat(gsPool.isDisposed()).as("isDisposed after invalidation/release").isTrue();
+		InstrumentedPool.PoolMetrics metrics = gsPool.metrics();
+		assertThat(metrics.idleSize()).as("idleSize").isZero();
+		assertThat(metrics.acquiredSize()).as("acquiredSize").isZero();
+		assertThat(metrics.pendingAcquireSize()).as("pendingAcquireSize").isZero();
+		assertThat(metrics.allocatedSize()).as("allocatedSize").isZero();
+	}
+
+	@Test
+	void gracefulShutdownTerminatesWhenAllInvalidated() {
+		gracefulShutdownTerminatesWhen((index, ref) -> ref.invalidate());
+	}
+
+	@Test
+	void gracefulShutdownTerminatesWhenAllReleased() {
+		gracefulShutdownTerminatesWhen((index, ref) -> ref.release());
+	}
+
+	@Test
+	void gracefulShutdownTerminatesWhenMixOfReleasedAndInvalidated() {
+		gracefulShutdownTerminatesWhen((index, ref) -> index % 2 == 0 ? ref.invalidate() : ref.release());
+	}
+	
+	@Test
+	void gracefulRefDuplicateInvalidate() {
+		AtomicLong source = new AtomicLong();
+
+		GracefulShutdownInstrumentedPool<Long> gsPool = PoolBuilder.from(Mono.fromSupplier(source::incrementAndGet))
+			.sizeBetween(0, 10)
+			.buildPoolAndDecorateWith(InstrumentedPoolDecorators::gracefulShutdown);
+
+		PooledRef<Long> ref1 = gsPool.acquire().block();
+		PooledRef<Long> ref2 = gsPool.acquire().block();
+
+		assertThat(gsPool.acquireTracker).hasValue(2);
+
+		ref1.invalidate().block();
+		ref1.invalidate().block();
+		ref1.invalidate().block();
+		ref1.invalidate().block();
+		ref1.invalidate().block();
+
+
+		assertThat(gsPool.acquireTracker).as("ref1 only").hasValue(1);
+
+		ref2.invalidate().block();
+		assertThat(gsPool.acquireTracker).as("ref1 and ref2").hasValue(0);
+	}
+
+	@Test
+	void gracefulRefDuplicateReleaseNoOp() {
+		AtomicLong source = new AtomicLong();
+
+		GracefulShutdownInstrumentedPool<Long> gsPool = PoolBuilder.from(Mono.fromSupplier(source::incrementAndGet))
+			.sizeBetween(0, 10)
+			.buildPoolAndDecorateWith(InstrumentedPoolDecorators::gracefulShutdown);
+
+		PooledRef<Long> ref1 = gsPool.acquire().block();
+		PooledRef<Long> ref2 = gsPool.acquire().block();
+
+		assertThat(gsPool.acquireTracker).hasValue(2);
+
+		ref1.release().block();
+		ref1.release().block();
+		ref1.release().block();
+		ref1.release().block();
+		ref1.release().block();
+
+
+		assertThat(gsPool.acquireTracker).as("ref1 only").hasValue(1);
+
+		ref2.invalidate().block();
+		assertThat(gsPool.acquireTracker).as("ref1 and ref2").hasValue(0);
+	}
+
+	@Test
+	void gracefulRefDuplicateInvalidateAndReleaseNoOp() {
+		AtomicLong source = new AtomicLong();
+
+		GracefulShutdownInstrumentedPool<Long> gsPool = PoolBuilder.from(Mono.fromSupplier(source::incrementAndGet))
+			.sizeBetween(0, 10)
+			.buildPoolAndDecorateWith(InstrumentedPoolDecorators::gracefulShutdown);
+
+		PooledRef<Long> ref1 = gsPool.acquire().block();
+		PooledRef<Long> ref2 = gsPool.acquire().block();
+
+		assertThat(gsPool.acquireTracker).hasValue(2);
+
+		ref1.release().block();
+		ref1.invalidate().block();
+		ref1.release().block();
+		ref1.invalidate().block();
+		ref1.release().block();
+
+		assertThat(gsPool.acquireTracker).as("ref1 only").hasValue(1);
+
+		ref2.invalidate().block();
+		assertThat(gsPool.acquireTracker).as("ref1 and ref2").hasValue(0);
+	}
+
+	@Test
+	void acquiredCountIfAcquireCancelled() {
+		AtomicLong source = new AtomicLong();
+
+		GracefulShutdownInstrumentedPool<Long> gsPool = PoolBuilder.from(Mono.fromSupplier(source::incrementAndGet))
+			.sizeBetween(0, 1)
+			.buildPoolAndDecorateWith(InstrumentedPoolDecorators::gracefulShutdown);
+
+		//go to capacity
+		gsPool.acquire().block();
+		//pending acquire
+		Disposable acquire2 = gsPool.acquire().subscribe();
+
+		assertThat(gsPool.acquireTracker).as("acquireTracker before cancel").hasValue(2);
+
+		acquire2.dispose();
+
+		assertThat(gsPool.acquireTracker).as("acquireTracker after cancel").hasValue(1);
+		assertThat(gsPool.metrics().pendingAcquireSize()).as("pendingAcquireSize").isZero();
+	}
+
+	@Test
+	void acquiredCountIfAcquireTtlCancelled() {
+		AtomicLong source = new AtomicLong();
+
+		GracefulShutdownInstrumentedPool<Long> gsPool = PoolBuilder.from(Mono.fromSupplier(source::incrementAndGet))
+			.sizeBetween(0, 1)
+			.buildPoolAndDecorateWith(InstrumentedPoolDecorators::gracefulShutdown);
+
+		//go to capacity
+		gsPool.acquire().block();
+		//pending acquire
+		Disposable acquire2 = gsPool.acquire(Duration.ofSeconds(5)).subscribe();
+
+		assertThat(gsPool.acquireTracker).as("acquireTracker before cancel").hasValue(2);
+
+		acquire2.dispose();
+
+		assertThat(gsPool.acquireTracker).as("acquireTracker after cancel").hasValue(1);
+		assertThat(gsPool.metrics().pendingAcquireSize()).as("pendingAcquireSize").isZero();
+	}
+}

--- a/src/test/java/reactor/pool/decorators/GracefulShutdownInstrumentedPoolTest.java
+++ b/src/test/java/reactor/pool/decorators/GracefulShutdownInstrumentedPoolTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.pool.decorators;
 
 import java.time.Duration;

--- a/src/test/java/reactor/pool/decorators/InstrumentedPoolDecoratorsTest.java
+++ b/src/test/java/reactor/pool/decorators/InstrumentedPoolDecoratorsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.pool.decorators;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/reactor/pool/decorators/InstrumentedPoolDecoratorsTest.java
+++ b/src/test/java/reactor/pool/decorators/InstrumentedPoolDecoratorsTest.java
@@ -1,0 +1,25 @@
+package reactor.pool.decorators;
+
+import org.junit.jupiter.api.Test;
+
+import reactor.core.publisher.Mono;
+import reactor.pool.InstrumentedPool;
+import reactor.pool.PoolBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Simon Baslé
+ */
+class InstrumentedPoolDecoratorsTest {
+
+	@Test
+	void decorateGracefulAsPartOfBuilder() {
+		InstrumentedPool<String> pool = PoolBuilder.from(Mono.just("foo"))
+			.sizeBetween(0, 5)
+			.buildPoolAndDecorateWith(InstrumentedPoolDecorators::gracefulShutdown);
+
+		assertThat(pool).isExactlyInstanceOf(GracefulShutdownInstrumentedPool.class);
+	}
+
+}


### PR DESCRIPTION
Work in progress.

This decorates any `InstrumentedPool`, returning an instance that adds `gracefulShutdown` method.
Using wrappers, it tracks acquired and acquiring calls and prevents further acquiring once graceful shutdown has started.
After that, is enough `release()` are made or if the timeout triggers, the pool is shut down for good.

Fixes #148 