### PR TITLE
Add config() accessor to Pool

### DIFF
--- a/src/main/java/reactor/pool/AbstractPool.java
+++ b/src/main/java/reactor/pool/AbstractPool.java
@@ -72,6 +72,11 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
 	// == pool introspection methods ==
 
 	@Override
+	public PoolConfig<POOLABLE> config() {
+		return this.poolConfig;
+	}
+
+	@Override
 	public PoolMetrics metrics() {
 		return this;
 	}

--- a/src/main/java/reactor/pool/Pool.java
+++ b/src/main/java/reactor/pool/Pool.java
@@ -136,6 +136,18 @@ public interface Pool<POOLABLE> extends Disposable {
 	}
 
 	/**
+	 * Return the pool's {@link PoolConfig configuration}.
+	 * <p>
+	 * Until 0.3.0, implementors MAY throw an {@link UnsupportedOperationException} instead,
+	 * although all vanilla reactor-pool implementation do return their configuration.
+	 *
+	 * @return the {@link PoolConfig}
+	 */
+	default PoolConfig<POOLABLE> config() {
+		throw new UnsupportedOperationException("This instance of Pool doesn't expose its configuration");
+	}
+
+	/**
 	 * Shutdown the pool by:
 	 * <ul>
 	 *     <li>


### PR DESCRIPTION
This commit adds an accessor for the immutable PoolConfig of pools.

The default version throws an `UnsupportedOperationException`, but all implementors will be required to override this in a future release (1.0.0 most likely).
