### PR TITLE
Add PoolConfig#pendingAcquireTimer config option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -284,6 +284,8 @@ task japicmp(type: JapicmpTask) {
   classExcludes = [
   ]
   methodExcludes = [
+          // New methods with default implementation
+          "reactor.pool.PoolConfig#acquireTimer()"
   ]
 }
 check.dependsOn japicmp

--- a/build.gradle
+++ b/build.gradle
@@ -285,7 +285,7 @@ task japicmp(type: JapicmpTask) {
   ]
   methodExcludes = [
           // New methods with default implementation
-          "reactor.pool.PoolConfig#acquireTimer()"
+          "reactor.pool.PoolConfig#pendingAcquireTimer()"
   ]
 }
 check.dependsOn japicmp

--- a/src/main/java/reactor/pool/AbstractPool.java
+++ b/src/main/java/reactor/pool/AbstractPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Function;
@@ -34,7 +33,6 @@ import reactor.core.Disposables;
 import reactor.core.Scannable;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;
-import reactor.core.scheduler.Schedulers;
 import reactor.util.Logger;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
@@ -391,16 +389,16 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
 
 		final CoreSubscriber<? super AbstractPooledRef<POOLABLE>> actual;
 		final AbstractPool<POOLABLE> pool;
-		final Duration acquireTimeout;
+		final Duration pendingAcquireTimeout;
 
 		Disposable timeoutTask;
 
 		Borrower(CoreSubscriber<? super AbstractPooledRef<POOLABLE>> actual,
 				AbstractPool<POOLABLE> pool,
-				Duration acquireTimeout) {
+				Duration pendingAcquireTimeout) {
 			this.actual = actual;
 			this.pool = pool;
-			this.acquireTimeout = acquireTimeout;
+			this.pendingAcquireTimeout = pendingAcquireTimeout;
 			this.timeoutTask = TIMEOUT_DISPOSED;
 		}
 
@@ -412,7 +410,7 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
 		public void run() {
 			if (Borrower.this.compareAndSet(false, true)) {
 				pool.cancelAcquire(Borrower.this);
-				actual.onError(new PoolAcquireTimeoutException(acquireTimeout));
+				actual.onError(new PoolAcquireTimeoutException(pendingAcquireTimeout));
 			}
 		}
 
@@ -424,8 +422,8 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
 				boolean noIdle = pool.idleSize() == 0;
 				boolean noPermits = pool.poolConfig.allocationStrategy().estimatePermitCount() == 0;
 
-				if (!acquireTimeout.isZero() && noIdle && noPermits) {
-					timeoutTask = this.pool.config().acquireTimer().apply(this, acquireTimeout);
+				if (!pendingAcquireTimeout.isZero() && noIdle && noPermits) {
+					timeoutTask = this.pool.config().pendingAcquireTimer().apply(this, pendingAcquireTimeout);
 				}
 				//doAcquire should interrupt the countdown if there is either an available
 				//resource or the pool can allocate one

--- a/src/main/java/reactor/pool/AbstractPool.java
+++ b/src/main/java/reactor/pool/AbstractPool.java
@@ -425,7 +425,7 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
 				boolean noPermits = pool.poolConfig.allocationStrategy().estimatePermitCount() == 0;
 
 				if (!acquireTimeout.isZero() && noIdle && noPermits) {
-					timeoutTask = Schedulers.parallel().schedule(this, acquireTimeout.toMillis(), TimeUnit.MILLISECONDS);
+					timeoutTask = this.pool.config().acquireTimer().apply(this, acquireTimeout);
 				}
 				//doAcquire should interrupt the countdown if there is either an available
 				//resource or the pool can allocate one

--- a/src/main/java/reactor/pool/DefaultPoolConfig.java
+++ b/src/main/java/reactor/pool/DefaultPoolConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import reactor.core.scheduler.Schedulers;
  */
 public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 
-	protected final BiFunction<Runnable, Duration, Disposable>    acquireTimer;
+	protected final BiFunction<Runnable, Duration, Disposable> 	  pendingAcquireTimer;
 	protected final Mono<POOLABLE>                                allocator;
 	protected final AllocationStrategy                            allocationStrategy;
 	protected final int                                           maxPending;
@@ -52,19 +52,19 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 	protected final boolean                                       isIdleLRU;
 
 	public DefaultPoolConfig(Mono<POOLABLE> allocator,
-							 AllocationStrategy allocationStrategy,
-							 int maxPending,
-							 BiFunction<Runnable, Duration, Disposable> acquireTimer,
-							 Function<POOLABLE, ? extends Publisher<Void>> releaseHandler,
-							 Function<POOLABLE, ? extends Publisher<Void>> destroyHandler,
-							 BiPredicate<POOLABLE, PooledRefMetadata> evictionPredicate,
-							 Duration evictInBackgroundInterval,
-							 Scheduler evictInBackgroundScheduler,
-							 Scheduler acquisitionScheduler,
-							 PoolMetricsRecorder metricsRecorder,
-							 Clock clock,
-							 boolean isIdleLRU) {
-		this.acquireTimer = acquireTimer;
+			AllocationStrategy allocationStrategy,
+			int maxPending,
+			BiFunction<Runnable, Duration, Disposable> pendingAcquireTimer,
+			Function<POOLABLE, ? extends Publisher<Void>> releaseHandler,
+			Function<POOLABLE, ? extends Publisher<Void>> destroyHandler,
+			BiPredicate<POOLABLE, PooledRefMetadata> evictionPredicate,
+			Duration evictInBackgroundInterval,
+			Scheduler evictInBackgroundScheduler,
+			Scheduler acquisitionScheduler,
+			PoolMetricsRecorder metricsRecorder,
+			Clock clock,
+			boolean isIdleLRU) {
+		this.pendingAcquireTimer = pendingAcquireTimer;
 		this.allocator = allocator;
 		this.allocationStrategy = allocationStrategy;
 		this.maxPending = maxPending;
@@ -96,7 +96,7 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 			PoolMetricsRecorder metricsRecorder,
 			Clock clock,
 			boolean isIdleLRU) {
-		this(allocator, allocationStrategy, maxPending, PoolBuilder.DEFAULT_ACQUIRE_TIMER, releaseHandler, destroyHandler, evictionPredicate, evictInBackgroundInterval,
+		this(allocator, allocationStrategy, maxPending, PoolBuilder.DEFAULT_PENDING_ACQUIRE_TIMER, releaseHandler, destroyHandler, evictionPredicate, evictInBackgroundInterval,
 				evictInBackgroundScheduler, acquisitionScheduler, metricsRecorder, clock, isIdleLRU);
 	}
 
@@ -153,7 +153,7 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 			this.allocator = toCopyDpc.allocator;
 			this.allocationStrategy = toCopyDpc.allocationStrategy;
 			this.maxPending = toCopyDpc.maxPending;
-			this.acquireTimer = toCopyDpc.acquireTimer;
+			this.pendingAcquireTimer = toCopyDpc.pendingAcquireTimer;
 			this.releaseHandler = toCopyDpc.releaseHandler;
 			this.destroyHandler = toCopyDpc.destroyHandler;
 			this.evictionPredicate = toCopyDpc.evictionPredicate;
@@ -168,7 +168,7 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 			this.allocator = toCopy.allocator();
 			this.allocationStrategy = toCopy.allocationStrategy();
 			this.maxPending = toCopy.maxPending();
-			this.acquireTimer = toCopy.acquireTimer();
+			this.pendingAcquireTimer = toCopy.pendingAcquireTimer();
 			this.releaseHandler = toCopy.releaseHandler();
 			this.destroyHandler = toCopy.destroyHandler();
 			this.evictionPredicate = toCopy.evictionPredicate();
@@ -197,8 +197,8 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 	}
 
 	@Override
-	public BiFunction<Runnable, Duration, Disposable> acquireTimer() {
-		return this.acquireTimer;
+	public BiFunction<Runnable, Duration, Disposable> pendingAcquireTimer() {
+		return this.pendingAcquireTimer;
 	}
 
 	@Override

--- a/src/main/java/reactor/pool/PoolConfig.java
+++ b/src/main/java/reactor/pool/PoolConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,17 +129,16 @@ public interface PoolConfig<POOLABLE> {
 	boolean reuseIdleResourcesInLruOrder();
 
 	/**
-	 * The function to apply when scheduling timers for acquisitions that are added to the pending queue.
-	 * i.e. there is no idle resource and no new resource can be created currently, so a timer is scheduled using the
-	 * returned function.
+	 * The function that defines how timeouts are scheduled when a {@link Pool#acquire(Duration)} call is made and the acquisition is pending.
+	 * i.e. there is no idle resource and no new resource can be created currently, so a timeout is scheduled using the returned function.
 	 * <p>
 	 *
 	 * By default, the {@link Schedulers#parallel()} scheduler is used.
 	 *
 	 * @return the function to apply when scheduling timers for pending acquisitions
 	 */
-	default BiFunction<Runnable, Duration, Disposable> acquireTimer() {
-		return PoolBuilder.DEFAULT_ACQUIRE_TIMER;
+	default BiFunction<Runnable, Duration, Disposable> pendingAcquireTimer() {
+		return PoolBuilder.DEFAULT_PENDING_ACQUIRE_TIMER;
 	}
 
 }

--- a/src/main/java/reactor/pool/PoolConfig.java
+++ b/src/main/java/reactor/pool/PoolConfig.java
@@ -18,11 +18,13 @@ package reactor.pool;
 
 import java.time.Clock;
 import java.time.Duration;
+import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 
 import org.reactivestreams.Publisher;
 
+import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -125,5 +127,19 @@ public interface PoolConfig<POOLABLE> {
 	 * @return {@code true} for LRU, {@code false} for MRU
 	 */
 	boolean reuseIdleResourcesInLruOrder();
+
+	/**
+	 * The function to apply when scheduling timers for acquisitions that are added to the pending queue.
+	 * i.e. there is no idle resource and no new resource can be created currently, so a timer is scheduled using the
+	 * returned function.
+	 * <p>
+	 *
+	 * By default, the {@link Schedulers#parallel()} scheduler is used.
+	 *
+	 * @return the function to apply when scheduling timers for pending acquisitions
+	 */
+	default BiFunction<Runnable, Duration, Disposable> acquireTimer() {
+		return PoolBuilder.DEFAULT_ACQUIRE_TIMER;
+	}
 
 }

--- a/src/test/java/reactor/pool/CommonPoolTest.java
+++ b/src/test/java/reactor/pool/CommonPoolTest.java
@@ -1524,7 +1524,7 @@ public class CommonPoolTest {
 				.from(Mono.just(resource))
 				.releaseHandler(atomic -> Mono.fromRunnable(atomic::incrementAndGet))
 				.sizeBetween(0, 1)
-				.acquireTimer((r, d) -> {
+				.pendingAcquireTimer((r, d) -> {
 					customTimeout.set(true);
 					return Schedulers.parallel().schedule(r, d.toMillis(), TimeUnit.MILLISECONDS);
 				});
@@ -1542,7 +1542,7 @@ public class CommonPoolTest {
 						.isExactlyInstanceOf(PoolAcquireTimeoutException.class)
 						.hasMessage("Pool#acquire(Duration) has been pending for more than the configured timeout of 100ms"));
 
-		assertThat(customTimeout).as("custom acquireTimer invoked").isTrue();
+		assertThat(customTimeout).as("custom pendingAcquireTimer invoked").isTrue();
 
 		assertThat(resource).as("post timeout but before resource available").hasValue(0);
 

--- a/src/test/java/reactor/pool/CommonPoolTest.java
+++ b/src/test/java/reactor/pool/CommonPoolTest.java
@@ -1517,6 +1517,41 @@ public class CommonPoolTest {
 
 	@ParameterizedTestWithName
 	@MethodSource("allPools")
+	void pendingTimeoutWithCustomAcquireTimer(Function<PoolBuilder<AtomicInteger, ?>, AbstractPool<AtomicInteger>> configAdjuster) {
+		AtomicInteger resource = new AtomicInteger();
+		AtomicBoolean customTimeout = new AtomicBoolean();
+		PoolBuilder<AtomicInteger, ?> builder = PoolBuilder
+				.from(Mono.just(resource))
+				.releaseHandler(atomic -> Mono.fromRunnable(atomic::incrementAndGet))
+				.sizeBetween(0, 1)
+				.acquireTimer((r, d) -> {
+					customTimeout.set(true);
+					return Schedulers.parallel().schedule(r, d.toMillis(), TimeUnit.MILLISECONDS);
+				});
+		AbstractPool<AtomicInteger> pool = configAdjuster.apply(builder);
+
+		PooledRef<AtomicInteger> uniqueRef = pool.acquire().block();
+		assert uniqueRef != null;
+
+		StepVerifier.withVirtualTime(() -> pool.acquire(Duration.ofMillis(100)).map(PooledRef::poolable))
+				.expectSubscription()
+				.expectNoEvent(Duration.ofMillis(100))
+				.thenAwait(Duration.ofMillis(1))
+				.verifyErrorSatisfies(e -> assertThat(e)
+						.isInstanceOf(TimeoutException.class)
+						.isExactlyInstanceOf(PoolAcquireTimeoutException.class)
+						.hasMessage("Pool#acquire(Duration) has been pending for more than the configured timeout of 100ms"));
+
+		assertThat(customTimeout).as("custom acquireTimer invoked").isTrue();
+
+		assertThat(resource).as("post timeout but before resource available").hasValue(0);
+
+		uniqueRef.release().block();
+		assertThat(resource).as("post timeout and after resource available").hasValue(1);
+	}
+
+	@ParameterizedTestWithName
+	@MethodSource("allPools")
 	void eachBorrowerCanOnlyReleaseOnce(Function<PoolBuilder<AtomicInteger, ?>, AbstractPool<AtomicInteger>> configAdjuster) {
 		AtomicInteger resource = new AtomicInteger();
 		PoolBuilder<AtomicInteger, ?> builder = PoolBuilder

--- a/src/test/java/reactor/pool/PoolBuilderTest.java
+++ b/src/test/java/reactor/pool/PoolBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package reactor.pool;
 
 import java.time.Duration;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
@@ -114,16 +113,16 @@ class PoolBuilderTest {
 	}
 
 	@Test
-	void acquireTimerCustomized() {
+	void pendingAcquireTimerCustomized() {
 		final BiFunction<Runnable, Duration, Disposable> customizedBiFunction = (r, d) -> {
 			r.run();
 			return Disposables.disposed();
 		};
 		PoolBuilder<Integer, PoolConfig<Integer>> poolBuilder = PoolBuilder.from(Mono.just(1))
-				.acquireTimer(customizedBiFunction);
+				.pendingAcquireTimer(customizedBiFunction);
 		PoolConfig<Integer> config = poolBuilder.buildConfig();
 
-		assertThat(config.acquireTimer()).isSameAs(customizedBiFunction);
+		assertThat(config.pendingAcquireTimer()).isSameAs(customizedBiFunction);
 	}
 
 	@Test


### PR DESCRIPTION
This is the PR to allow to configure the reactor-pool with a custom user timer service that can be used for pending acquisitions (thanks a lot to Simon for the help).

@simonbasle, **please do not merge for the moment**, because Violeta wants to investigate the timer issue before merging anything. And there is still the documentation to update; so, please do not review for the moment.


thanks !
  