### PR TITLE
Improve JapiCmp: avoid misses, improve reporting and exclusions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -256,6 +256,28 @@ task downloadBaseline(type: Download) {
   dest "${buildDir}/baselineLibs/reactor-pool-${libs.versions.baseline.pool.api.get()}.jar"
 }
 
+def japicmpReport = tasks.register('japicmpReport') {
+  onlyIf {
+    japicmp.state.failure != null
+  }
+  doLast {
+    def reportFile = file("${project.buildDir}/reports/japi.txt")
+    if (reportFile.exists()) {
+      println "\n **********************************"
+      println " * /!\\ API compatibility failures *"
+      println " **********************************"
+      println "Japicmp report was filtered and interpreted to find the following incompatibilities:"
+      reportFile.eachLine {
+        if (it.contains("*") && (!it.contains("***") || it.contains("****")))
+          println "source incompatible change: $it"
+        else if (it.contains("!"))
+          println "binary incompatible change: $it"
+      }
+    }
+    else println "No incompatible change to report"
+  }
+}
+
 task japicmp(type: JapicmpTask) {
   if (project.gradle.startParameter.isOffline()) {
     println "Offline: skipping downloading of baseline and JAPICMP"
@@ -268,33 +290,29 @@ task japicmp(type: JapicmpTask) {
   else {
     println "Will download and perform baseline comparison with ${libs.versions.baseline.pool.api.get()}"
     dependsOn(downloadBaseline)
+    finalizedBy(japicmpReport)
   }
 
-  oldClasspath = tasks.downloadBaseline.outputs.files
-  newClasspath = tasks.jar.outputs.files
-  onlyBinaryIncompatibleModified = true
+  oldClasspath.from(tasks.downloadBaseline.outputs.files)
+  newClasspath.from(tasks.jar.outputs.files)
+  // these onlyXxx parameters result in a report that is slightly too noisy, but better than
+  // onlyBinaryIncompatibleModified = true which masks source-incompatible-only changes
+  onlyBinaryIncompatibleModified = false
+  onlyModified = true
   failOnModification = true
   failOnSourceIncompatibility = true
   txtOutputFile = file("${project.buildDir}/reports/japi.txt")
   ignoreMissingClasses = true
   includeSynthetic = true
+  compatibilityChangeExcludes = [ "METHOD_NEW_DEFAULT" ]
 
   //TODO after a release, bump the gradle.properties baseline
   //TODO after a release, remove the reactor-pool exclusions below if any
   classExcludes = [
   ]
-  methodExcludes = [
-          // New methods with default implementation
-          "reactor.pool.PoolConfig#pendingAcquireTimer()"
-  ]
+  methodExcludes = [ ]
 }
 check.dependsOn japicmp
-
-gradle.taskGraph.afterTask { task, state ->
-  if (task instanceof JapicmpTask && state.failure) {
-    print file("${project.buildDir}/reports/japi.txt").getText()
-  }
-}
 
 jcstress {
   mode = 'default' //quick, default, tough

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,6 @@ slf4j-jcl = { module = "org.slf4j:jcl-over-slf4j", version.ref = "slf4j" }
 artifactory = { id = "com.jfrog.artifactory", version = "4.27.1" }
 bnd = { id = "biz.aQute.bnd.builder", version = "6.1.0" }
 download = { id = "de.undercouch.download", version = "5.0.1" }
-japicmp = { id = "me.champeau.gradle.japicmp", version = "0.3.0" }
+japicmp = { id = "me.champeau.gradle.japicmp", version = "0.4.1" }
 jcstress = { id = "io.github.reyerizo.gradle.jcstress", version = "0.8.13" }
 spotless = { id = "com.diffplug.spotless", version = "6.3.0" }


### PR DESCRIPTION
This commit improves the japicmp integration in the build:

1) Add a finalizedBy task that prints a filtered report

The basic text report uses * and ! as markers for binary and source
incompatible changes respectively. Additionally, a MODIFIED class is
marked with ***. This task attempts at pinpointing the incompatible
changes only in the report, and printing these lines.

This report is called out in the "how to fix" tip in the CI preliminary
step.

2) Ensure sourceModified changes are considered

See reactor/reactor#722.

If a change is binary compatible but not source compatible, using
`onlyBinaryCompatibleModified = true` will mask the issue. This
change uses `onlyModified = true` instead. This is slightly more
verbose, but this is alleviated by (1).

3) Update japicmp-gradle-plugin, exclude NEW_DEFAULT_METHOD as a whole

Since japicmp-grale-plugin v0.4.1 the new `compatibilityChangeExcludes`
parameter allows us to ignore all occurrences of a default method added
to an interface, instead of having to exclude each such method one by
one.
