### PR TITLE
Add `reactor-pool-micrometer` module with recorder and gauges

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,8 +61,6 @@ ext {
     jdkJavadoc = "https://docs.oracle.com/en/java/javase/$jdk/docs/api/"
   }
   println "JDK Javadoc link for this build is ${rootProject.jdkJavadoc}"
-
-  osgiVersion = osgiVersion(version.toString())
 }
 
 spotless {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 version=1.0.0-SNAPSHOT
+reactorPoolMicrometerVersion=0.1.0-SNAPSHOT

--- a/gradle/doc.gradle
+++ b/gradle/doc.gradle
@@ -32,13 +32,18 @@ javadoc {
 	options.memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PROTECTED
 	options.author = true
 	options.stylesheetFile = file("$rootDir/docs/api/stylesheet.css")
-	options.links([
+
+	String[] links = [
 		"https://projectreactor.io/docs/core/${libs.versions.reactorCore.get()}/api/",
 		jdkJavadoc,
 		//forcing RS javadoc on version 1.0.3 as it appears 1.0.4 cannot be reached/consumed
 		"https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/"
-		//TODO add micrometer ?
-	] as String[])
+	]
+	if (project.name != 'reactor-pool') {
+		//TODO currently java 8 cannot link to Micrometer javadocs deployed to javadoc.io
+		links += "https://projectreactor.io/docs/pool/${libs.versions.baseline.pool.api.get()}/api/"
+	}
+	options.links(links)
 
 	maxMemory = "1024m"
 	destinationDir = new File(project.buildDir, "docs/javadoc")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,8 +18,8 @@ jsr305 = "com.google.code.findbugs:jsr305:3.0.1"
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 logback = "ch.qos.logback:logback-classic:1.2.11"
 micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometer" }
-micrometer-commons = { module = "io.micrometer:micrometer-commons" }
 micrometer-core = { module = "io.micrometer:micrometer-core" }
+micrometer-test = { module = "io.micrometer:micrometer-test" }
 mockito = "org.mockito:mockito-core:4.8.0"
 reactor-core = { module = "io.projectreactor:reactor-core", version.ref = "reactorCore" }
 reactor-test = { module = "io.projectreactor:reactor-test", version.ref = "reactorCore" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ reactorAddons = "3.5.0-SNAPSHOT"
 # Other shared versions
 junit = "5.9.1"
 slf4j = "1.7.36"
+micrometer = "1.10.0-M6"
 reactiveStreams = "1.0.4"
 
 [libraries]
@@ -16,6 +17,9 @@ hdrHistogram = "org.hdrhistogram:HdrHistogram:2.1.12"
 jsr305 = "com.google.code.findbugs:jsr305:3.0.1"
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 logback = "ch.qos.logback:logback-classic:1.2.11"
+micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometer" }
+micrometer-commons = { module = "io.micrometer:micrometer-commons" }
+micrometer-core = { module = "io.micrometer:micrometer-core" }
 mockito = "org.mockito:mockito-core:4.8.0"
 reactor-core = { module = "io.projectreactor:reactor-core", version.ref = "reactorCore" }
 reactor-test = { module = "io.projectreactor:reactor-test", version.ref = "reactorCore" }

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -69,12 +69,17 @@ task qualifyVersionGha() {
 	doLast {
 		def versionType = qualifyVersion("$version")
 
-		println "::set-output name=versionType::$versionType"
-		println "::set-output name=fullVersion::$version"
 		if (versionType == "BAD") {
 			println "::error ::Unable to parse $version to a VersionNumber with recognizable qualifier"
 			throw new TaskExecutionException(tasks.getByName("qualifyVersionGha"), new IllegalArgumentException("Unable to parse $version to a VersionNumber with recognizable qualifier"))
 		}
+		//only consider reactor-pool for releasing (version type, tagging, etc...)
+		if (project.name != 'reactor-pool') {
+			return
+		}
+		println "::set-output name=versionType::$versionType"
+		println "::set-output name=fullVersion::$version"
+
 		println "Recognized $version as $versionType"
 	}
 }

--- a/reactor-pool-micrometer/build.gradle
+++ b/reactor-pool-micrometer/build.gradle
@@ -20,6 +20,7 @@ apply plugin: 'java-library'
 description = 'Micrometer metrics support for Reactor Pool'
 
 ext {
+    shortName = "Reactor Pool Micrometer"
     bndOptions = [
       "Export-Package": [
         "!*internal*",

--- a/reactor-pool-micrometer/build.gradle
+++ b/reactor-pool-micrometer/build.gradle
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'biz.aQute.bnd.builder'
+apply plugin: 'java-library'
+
+description = 'Micrometer metrics support for Reactor Pool'
+
+ext {
+    bndOptions = [
+      "Export-Package": [
+        "!*internal*",
+        "reactor.pool.introspection.micrometer.*;version=$osgiVersion"
+      ].join(","),
+      "Import-Package": [
+        "!javax.annotation",
+        "*"
+      ].join(","),
+      "Bundle-Name" : "reactor-pool-micrometer",
+      "Bundle-SymbolicName" : "io.projectreactor.addons.reactor-pool-micrometer",
+      "Bundle-Version" : "$osgiVersion"
+    ]
+}
+
+dependencies {
+    api libs.reactor.core
+    api project(":reactor-pool")
+
+    api platform(libs.micrometer.bom)
+    api libs.micrometer.core
+    testImplementation platform(libs.micrometer.bom)
+    testImplementation libs.micrometer.core
+
+    // JSR-305 annotations
+    compileOnly libs.jsr305
+
+    // Testing
+    testImplementation libs.assertj
+    testRuntimeOnly libs.slf4j.jcl
+    testRuntimeOnly libs.logback
+    testImplementation libs.reactor.test
+    testImplementation platform(libs.junit.bom)
+    testImplementation "org.junit.jupiter:junit-jupiter-api"
+    testImplementation "org.junit.jupiter:junit-jupiter-params"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
+}
+
+//TODO Add japicmp once GA reached
+
+jar {
+    manifest {
+        attributes("Created-By": "${System.getProperty("java.version")} (${System.getProperty("java.specification.vendor")})",
+          "Implementation-Title": project.name,
+          "Implementation-Version": project.version,
+          "Automatic-Module-Name": "reactor.pool.micrometer")
+    }
+    bnd(bndOptions)
+}
+
+check.dependsOn jacocoTestReport

--- a/reactor-pool-micrometer/build.gradle
+++ b/reactor-pool-micrometer/build.gradle
@@ -18,9 +18,11 @@ apply plugin: 'biz.aQute.bnd.builder'
 apply plugin: 'java-library'
 
 description = 'Micrometer metrics support for Reactor Pool'
+version = "$reactorPoolMicrometerVersion"
 
 ext {
     shortName = "Reactor Pool Micrometer"
+    osgiVersion = osgiVersion(version.toString())
     bndOptions = [
       "Export-Package": [
         "!*internal*",

--- a/reactor-pool-micrometer/build.gradle
+++ b/reactor-pool-micrometer/build.gradle
@@ -37,13 +37,16 @@ ext {
 }
 
 dependencies {
+    // Reactor
     api libs.reactor.core
     api project(":reactor-pool")
 
+    // Micrometer
     api platform(libs.micrometer.bom)
     api libs.micrometer.core
+    // Micrometer for tests
     testImplementation platform(libs.micrometer.bom)
-    testImplementation libs.micrometer.core
+    testImplementation libs.micrometer.test
 
     // JSR-305 annotations
     compileOnly libs.jsr305

--- a/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/DocumentedPoolMeters.java
+++ b/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/DocumentedPoolMeters.java
@@ -34,7 +34,7 @@ enum DocumentedPoolMeters implements DocumentedMeter {
 
 		@Override
 		public Meter.Type getType() {
-			return Meter.Type.COUNTER;
+			return Meter.Type.GAUGE;
 		}
 	},
 	ALLOCATED {
@@ -45,7 +45,7 @@ enum DocumentedPoolMeters implements DocumentedMeter {
 
 		@Override
 		public Meter.Type getType() {
-			return Meter.Type.COUNTER;
+			return Meter.Type.GAUGE;
 		}
 	},
 	IDLE {
@@ -56,7 +56,7 @@ enum DocumentedPoolMeters implements DocumentedMeter {
 
 		@Override
 		public Meter.Type getType() {
-			return Meter.Type.COUNTER;
+			return Meter.Type.GAUGE;
 		}
 	},
 	PENDING_ACQUIRE {
@@ -67,7 +67,7 @@ enum DocumentedPoolMeters implements DocumentedMeter {
 
 		@Override
 		public Meter.Type getType() {
-			return Meter.Type.COUNTER;
+			return Meter.Type.GAUGE;
 		}
 	},
 
@@ -97,7 +97,7 @@ enum DocumentedPoolMeters implements DocumentedMeter {
 
 		@Override
 		public Meter.Type getType() {
-			return Meter.Type.DISTRIBUTION_SUMMARY;
+			return Meter.Type.TIMER;
 		}
 	},
 
@@ -109,7 +109,7 @@ enum DocumentedPoolMeters implements DocumentedMeter {
 
 		@Override
 		public Meter.Type getType() {
-			return Meter.Type.DISTRIBUTION_SUMMARY;
+			return Meter.Type.TIMER;
 		}
 	},
 
@@ -121,7 +121,7 @@ enum DocumentedPoolMeters implements DocumentedMeter {
 
 		@Override
 		public Meter.Type getType() {
-			return Meter.Type.DISTRIBUTION_SUMMARY;
+			return Meter.Type.TIMER;
 		}
 	},
 
@@ -163,7 +163,7 @@ enum DocumentedPoolMeters implements DocumentedMeter {
 
 		@Override
 		public Meter.Type getType() {
-			return Meter.Type.DISTRIBUTION_SUMMARY;
+			return Meter.Type.TIMER;
 		}
 	};
 

--- a/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/DocumentedPoolMeters.java
+++ b/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/DocumentedPoolMeters.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool.introspection.micrometer;
+
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.docs.DocumentedMeter;
+
+/**
+ * Meters used by {@link Micrometer} utility.
+ */
+enum DocumentedPoolMeters implements DocumentedMeter {
+
+	ACQUIRED {
+		@Override
+		public String getName() {
+			return "%s.resources.acquired";
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.COUNTER;
+		}
+	},
+	ALLOCATED {
+		@Override
+		public String getName() {
+			return "%s.resources.allocated";
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.COUNTER;
+		}
+	},
+	IDLE {
+		@Override
+		public String getName() {
+			return "%s.resources.idle";
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.COUNTER;
+		}
+	},
+	PENDING_ACQUIRE {
+		@Override
+		public String getName() {
+			return "%s.resources.pendingAcquire";
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.COUNTER;
+		}
+	},
+
+
+	ALLOCATION {
+		@Override
+		public String getName() {
+			return "%s.allocation";
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.TIMER;
+		}
+
+		@Override
+		public KeyName[] getKeyNames() {
+			return AllocationTags.values();
+		}
+	},
+
+	DESTROYED {
+		@Override
+		public String getName() {
+			return "%s.destroyed";
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.DISTRIBUTION_SUMMARY;
+		}
+	},
+
+	SUMMARY_IDLENESS {
+		@Override
+		public String getName() {
+			return "%s.resources.summary.idleness";
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.DISTRIBUTION_SUMMARY;
+		}
+	},
+
+	SUMMARY_LIFETIME {
+		@Override
+		public String getName() {
+			return "%s.resources.summary.lifetime";
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.DISTRIBUTION_SUMMARY;
+		}
+	},
+
+	RECYCLED {
+		@Override
+		public String getName() {
+			return "%s.recycled";
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.COUNTER;
+		}
+	},
+
+	RECYCLED_NOTABLE {
+		@Override
+		public String getName() {
+			return "%s.recycled.notable";
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.COUNTER;
+		}
+
+		@Override
+		public KeyName[] getKeyNames() {
+			return RecycledNotableTags.values();
+		}
+	},
+
+
+	RESET {
+		@Override
+		public String getName() {
+			return "%s.reset";
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.DISTRIBUTION_SUMMARY;
+		}
+	};
+
+	public enum AllocationTags implements KeyName {
+
+		/**
+		 * Indicates whether the allocation timed was a {@code success} or {@code failure}.
+		 */
+		OUTCOME {
+			@Override
+			public String asString() {
+				return "pool.allocation.outcome";
+			}
+		};
+
+		public static final Tag OUTCOME_SUCCESS = Tag.of(OUTCOME.asString(), "success");
+		public static final Tag OUTCOME_FAILURE = Tag.of(OUTCOME.asString(), "failure");
+
+	}
+
+	public enum RecycledNotableTags implements KeyName {
+
+		/**
+		 * Indicates that a notable recycling path was used (as opposed to the common
+		 * one): either the {@code slow} path or the {@code fast} path.
+		 */
+		PATH {
+			@Override
+			public String asString() {
+				return "pool.recycling.path";
+			}
+		};
+
+		public static final Tag PATH_SLOW = Tag.of(PATH.asString(), "slow");
+		public static final Tag PATH_FAST = Tag.of(PATH.asString(), "fast");
+
+
+	}
+}

--- a/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/DocumentedPoolMeters.java
+++ b/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/DocumentedPoolMeters.java
@@ -23,6 +23,8 @@ import io.micrometer.core.instrument.docs.DocumentedMeter;
 
 /**
  * Meters used by {@link Micrometer} utility.
+ *
+ * @author Simon Baslé
  */
 enum DocumentedPoolMeters implements DocumentedMeter {
 

--- a/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/DocumentedPoolMeters.java
+++ b/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/DocumentedPoolMeters.java
@@ -29,53 +29,72 @@ enum DocumentedPoolMeters implements DocumentedMeter {
 	ACQUIRED {
 		@Override
 		public String getName() {
-			return "%s.resources.acquired";
+			return "reactor.pool.resources.acquired";
 		}
 
 		@Override
 		public Meter.Type getType() {
 			return Meter.Type.GAUGE;
+		}
+
+		@Override
+		public KeyName[] getKeyNames() {
+			return CommonTags.values();
 		}
 	},
 	ALLOCATED {
 		@Override
 		public String getName() {
-			return "%s.resources.allocated";
+			return "reactor.pool.resources.allocated";
 		}
 
 		@Override
 		public Meter.Type getType() {
 			return Meter.Type.GAUGE;
+		}
+
+		@Override
+		public KeyName[] getKeyNames() {
+			return CommonTags.values();
 		}
 	},
 	IDLE {
 		@Override
 		public String getName() {
-			return "%s.resources.idle";
+			return "reactor.pool.resources.idle";
 		}
 
 		@Override
 		public Meter.Type getType() {
 			return Meter.Type.GAUGE;
+		}
+
+		@Override
+		public KeyName[] getKeyNames() {
+			return CommonTags.values();
 		}
 	},
 	PENDING_ACQUIRE {
 		@Override
 		public String getName() {
-			return "%s.resources.pendingAcquire";
+			return "reactor.pool.resources.pendingAcquire";
 		}
 
 		@Override
 		public Meter.Type getType() {
 			return Meter.Type.GAUGE;
 		}
-	},
 
+		@Override
+		public KeyName[] getKeyNames() {
+			return CommonTags.values();
+		}
+	},
 
 	ALLOCATION {
 		@Override
 		public String getName() {
-			return "%s.allocation";
+			return "reactor.pool.allocation";
 		}
 
 		@Override
@@ -85,62 +104,65 @@ enum DocumentedPoolMeters implements DocumentedMeter {
 
 		@Override
 		public KeyName[] getKeyNames() {
-			return AllocationTags.values();
+			return KeyName.merge(CommonTags.values(), AllocationTags.values());
 		}
 	},
 
 	DESTROYED {
 		@Override
 		public String getName() {
-			return "%s.destroyed";
+			return "reactor.pool.destroyed";
 		}
 
 		@Override
 		public Meter.Type getType() {
 			return Meter.Type.TIMER;
+		}
+
+		@Override
+		public KeyName[] getKeyNames() {
+			return CommonTags.values();
 		}
 	},
 
 	SUMMARY_IDLENESS {
 		@Override
 		public String getName() {
-			return "%s.resources.summary.idleness";
+			return "reactor.pool.resources.summary.idleness";
 		}
 
 		@Override
 		public Meter.Type getType() {
 			return Meter.Type.TIMER;
+		}
+
+		@Override
+		public KeyName[] getKeyNames() {
+			return CommonTags.values();
 		}
 	},
 
 	SUMMARY_LIFETIME {
 		@Override
 		public String getName() {
-			return "%s.resources.summary.lifetime";
+			return "reactor.pool.resources.summary.lifetime";
 		}
 
 		@Override
 		public Meter.Type getType() {
 			return Meter.Type.TIMER;
 		}
+
+		@Override
+		public KeyName[] getKeyNames() {
+			return CommonTags.values();
+		}
 	},
 
 	RECYCLED {
 		@Override
 		public String getName() {
-			return "%s.recycled";
-		}
-
-		@Override
-		public Meter.Type getType() {
-			return Meter.Type.COUNTER;
-		}
-	},
-
-	RECYCLED_NOTABLE {
-		@Override
-		public String getName() {
-			return "%s.recycled.notable";
+			return "reactor.pool.recycled";
 		}
 
 		@Override
@@ -150,20 +172,41 @@ enum DocumentedPoolMeters implements DocumentedMeter {
 
 		@Override
 		public KeyName[] getKeyNames() {
-			return RecycledNotableTags.values();
+			return CommonTags.values();
 		}
 	},
 
+	RECYCLED_NOTABLE {
+		@Override
+		public String getName() {
+			return "reactor.pool.recycled.notable";
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.COUNTER;
+		}
+
+		@Override
+		public KeyName[] getKeyNames() {
+			return KeyName.merge(CommonTags.values(), RecycledNotableTags.values());
+		}
+	},
 
 	RESET {
 		@Override
 		public String getName() {
-			return "%s.reset";
+			return "reactor.pool.reset";
 		}
 
 		@Override
 		public Meter.Type getType() {
 			return Meter.Type.TIMER;
+		}
+
+		@Override
+		public KeyName[] getKeyNames() {
+			return CommonTags.values();
 		}
 	};
 
@@ -201,5 +244,15 @@ enum DocumentedPoolMeters implements DocumentedMeter {
 		public static final Tag PATH_FAST = Tag.of(PATH.asString(), "fast");
 
 
+	}
+
+	public enum CommonTags implements KeyName {
+
+		POOL_NAME {
+			@Override
+			public String asString() {
+				return "pool.name";
+			}
+		}
 	}
 }

--- a/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/Micrometer.java
+++ b/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/Micrometer.java
@@ -28,6 +28,8 @@ import static reactor.pool.introspection.micrometer.DocumentedPoolMeters.CommonT
 
 /**
  * Micrometer supporting utilities for instrumentation of reactor-pool.
+ *
+ * @author Simon Baslé
  */
 public final class Micrometer {
 

--- a/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/Micrometer.java
+++ b/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/Micrometer.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool.introspection.micrometer;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import reactor.pool.InstrumentedPool;
+import reactor.pool.PoolBuilder;
+import reactor.pool.PoolMetricsRecorder;
+
+/**
+ * Micrometer supporting utilities for instrumentation of reactor-pool.
+ */
+public final class Micrometer {
+
+	/**
+	 * Create an {@link InstrumentedPool} that publishes metrics to a Micrometer {@link MeterRegistry} using the provided {@code metricsPrefix}
+	 * for naming meters, starting from the provided {@link PoolBuilder}.
+	 * <p>
+	 * The steps involved are as follows:
+	 * <ol>
+	 *     <li> create a {@link PoolMetricsRecorder} similar to {@link #recorder(String, MeterRegistry)} </li>
+	 *     <li> mutate the builder to use that recorder by calling {@link PoolBuilder#metricsRecorder(PoolMetricsRecorder)} </li>
+	 *     <li> create an {@link InstrumentedPool} via {@link PoolBuilder#buildPool()} </li>
+	 *     <li> instrument the {@link reactor.pool.InstrumentedPool.PoolMetrics} via {@link #gaugesOf(InstrumentedPool.PoolMetrics, String, MeterRegistry)} </li>
+	 *     <li> return that {@link InstrumentedPool} instance </li>
+	 * </ol>
+	 *
+	 * @param poolBuilder a pre-configured {@link PoolBuilder} on which to configure a {@link PoolMetricsRecorder}
+	 * @param metricsPrefix the prefix to use for naming the gauges and the recorder's meters
+	 * @param meterRegistry the registry to use for the gauges and the recorder's meters
+	 * @param <POOLABLE> the type of resources in the pool
+	 * @return a new {@link InstrumentedPool} with a Micrometer recorder and with gauges attached
+	 * @see DocumentedPoolMeters
+	 */
+	public static <POOLABLE> InstrumentedPool<POOLABLE> instrumentedPool(PoolBuilder<POOLABLE, ?> poolBuilder, String metricsPrefix, MeterRegistry meterRegistry) {
+		PoolMetricsRecorder recorder = recorder(metricsPrefix, meterRegistry);
+		InstrumentedPool<POOLABLE> pool = poolBuilder.metricsRecorder(recorder).buildPool();
+		gaugesOf(pool.metrics(), metricsPrefix, meterRegistry);
+		return pool;
+	}
+
+	/**
+	 * Register Micrometer gauges around the {@link InstrumentedPool}'s {@link reactor.pool.InstrumentedPool.PoolMetrics}, using the
+	 * provided prefix and publishing to the provided {@link MeterRegistry}.
+	 * <p>
+	 * {@link DocumentedPoolMeters} include the gauges which are:
+	 * <ul>
+	 *     <li> {@link DocumentedPoolMeters#ACQUIRED} </li>
+	 *     <li> {@link DocumentedPoolMeters#ALLOCATED}, </li>
+	 *     <li> {@link DocumentedPoolMeters#IDLE} </li>
+	 *     <li> {@link DocumentedPoolMeters#PENDING_ACQUIRE} </li>
+	 * </ul>
+	 *
+	 * @param poolMetrics the {@link reactor.pool.InstrumentedPool.PoolMetrics} to turn into gauges
+	 * @param metricsPrefix the prefix to use for naming the gauges
+	 * @param meterRegistry the registry to use for the gauges
+	 * @see DocumentedPoolMeters
+	 * @see #instrumentedPool(PoolBuilder, String, MeterRegistry)
+	 */
+	public static void gaugesOf(InstrumentedPool.PoolMetrics poolMetrics, String metricsPrefix, MeterRegistry meterRegistry) {
+		Gauge.builder(
+				DocumentedPoolMeters.ACQUIRED.getName(metricsPrefix), poolMetrics,
+				InstrumentedPool.PoolMetrics::acquiredSize)
+			.register(meterRegistry);
+		Gauge.builder(
+				DocumentedPoolMeters.ALLOCATED.getName(metricsPrefix), poolMetrics,
+				InstrumentedPool.PoolMetrics::allocatedSize)
+			.register(meterRegistry);
+		Gauge.builder(
+				DocumentedPoolMeters.IDLE.getName(metricsPrefix), poolMetrics,
+				InstrumentedPool.PoolMetrics::idleSize)
+			.register(meterRegistry);
+		Gauge.builder(
+				DocumentedPoolMeters.PENDING_ACQUIRE.getName(metricsPrefix), poolMetrics,
+				InstrumentedPool.PoolMetrics::pendingAcquireSize)
+			.register(meterRegistry);
+	}
+
+	/**
+	 * Create a {@link PoolMetricsRecorder} publishing timers and other meters to a provided {@link MeterRegistry},
+	 * using the {@code metricsPrefix} for naming the meters.
+	 * <p>
+	 * {@link DocumentedPoolMeters} include the recorder-specific meters which are:
+	 * <ul>
+	 *     <li> {@link DocumentedPoolMeters#ALLOCATION} </li>
+	 *     <li> {@link DocumentedPoolMeters#DESTROYED}, </li>
+	 *     <li> {@link DocumentedPoolMeters#RECYCLED} </li>
+	 *     <li> {@link DocumentedPoolMeters#RESET} </li>
+	 *     <li> {@link DocumentedPoolMeters#SUMMARY_IDLENESS} </li>
+	 *     <li> {@link DocumentedPoolMeters#SUMMARY_LIFETIME} </li>
+	 * </ul>
+	 *
+	 * @param metricsPrefix the prefix to use for naming the recorder's meters
+	 * @param meterRegistry the registry to use for the recorder's meters
+	 * @return a Micrometer {@link PoolMetricsRecorder}
+	 * @see DocumentedPoolMeters
+	 * @see #instrumentedPool(PoolBuilder, String, MeterRegistry)
+	 */
+	public static PoolMetricsRecorder recorder(String metricsPrefix, MeterRegistry meterRegistry) {
+		return new MicrometerMetricsRecorder(metricsPrefix, meterRegistry);
+	}
+}

--- a/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/MicrometerMetricsRecorder.java
+++ b/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/MicrometerMetricsRecorder.java
@@ -26,51 +26,44 @@ import io.micrometer.core.instrument.Timer;
 
 import reactor.pool.PoolMetricsRecorder;
 
+import static reactor.pool.introspection.micrometer.DocumentedPoolMeters.*;
+import static reactor.pool.introspection.micrometer.DocumentedPoolMeters.AllocationTags.OUTCOME_FAILURE;
+import static reactor.pool.introspection.micrometer.DocumentedPoolMeters.AllocationTags.OUTCOME_SUCCESS;
+import static reactor.pool.introspection.micrometer.DocumentedPoolMeters.RecycledNotableTags.PATH_FAST;
+import static reactor.pool.introspection.micrometer.DocumentedPoolMeters.RecycledNotableTags.PATH_SLOW;
+
 final class MicrometerMetricsRecorder implements PoolMetricsRecorder {
 
 	private final String        metricsPrefix;
 	private final MeterRegistry meterRegistry;
 
-	private final Timer               allocationFailureTimer;
-	private final Timer               allocationSuccessTimer;
-	private final DistributionSummary destroyedMeter;
-	private final Counter             recycledCounter;
-	private final Counter             recycledNotableFastPathCounter;
-	private final Counter             recycledNotableSlowPathCounter;
-	private final DistributionSummary resetMeter;
-	private final DistributionSummary resourceSummaryIdleness;
-	private final DistributionSummary resourceSummaryLifetime;
+	private final Timer   allocationFailureTimer;
+	private final Timer   allocationSuccessTimer;
+	private final Timer   destroyedMeter;
+	private final Counter recycledCounter;
+	private final Counter recycledNotableFastPathCounter;
+	private final Counter recycledNotableSlowPathCounter;
+	private final Timer   resetMeter;
+	private final Timer   resourceSummaryIdleness;
+	private final Timer   resourceSummaryLifetime;
 
 	MicrometerMetricsRecorder(String metricsPrefix, MeterRegistry registry) {
 		this.metricsPrefix = metricsPrefix;
 		this.meterRegistry = registry;
 
-		allocationSuccessTimer = this.meterRegistry.timer(
-			DocumentedPoolMeters.ALLOCATION.getName(this.metricsPrefix),
-			Tags.of(DocumentedPoolMeters.AllocationTags.OUTCOME_SUCCESS));
-		allocationFailureTimer = this.meterRegistry.timer(
-			DocumentedPoolMeters.ALLOCATION.getName(this.metricsPrefix),
-			Tags.of(DocumentedPoolMeters.AllocationTags.OUTCOME_FAILURE));
+		allocationSuccessTimer = this.meterRegistry.timer(ALLOCATION.getName(this.metricsPrefix), Tags.of(OUTCOME_SUCCESS));
+		allocationFailureTimer = this.meterRegistry.timer(ALLOCATION.getName(this.metricsPrefix), Tags.of(OUTCOME_FAILURE));
 
-		resetMeter = this.meterRegistry.summary(
-			DocumentedPoolMeters.RESET.getName(this.metricsPrefix));
-		destroyedMeter = this.meterRegistry.summary(
-			DocumentedPoolMeters.DESTROYED.getName(this.metricsPrefix));
+		resetMeter = this.meterRegistry.timer(RESET.getName(this.metricsPrefix));
+		destroyedMeter = this.meterRegistry.timer(DESTROYED.getName(this.metricsPrefix));
 
-		recycledCounter = this.meterRegistry.counter(
-			DocumentedPoolMeters.RECYCLED.getName(this.metricsPrefix));
+		recycledCounter = this.meterRegistry.counter(RECYCLED.getName(this.metricsPrefix));
 
-		recycledNotableFastPathCounter = this.meterRegistry.counter(
-			DocumentedPoolMeters.RECYCLED_NOTABLE.getName(this.metricsPrefix),
-			Tags.of(DocumentedPoolMeters.RecycledNotableTags.PATH_FAST));
-		recycledNotableSlowPathCounter = this.meterRegistry.counter(
-			DocumentedPoolMeters.RECYCLED_NOTABLE.getName(this.metricsPrefix),
-			Tags.of(DocumentedPoolMeters.RecycledNotableTags.PATH_SLOW));
+		recycledNotableFastPathCounter = this.meterRegistry.counter(RECYCLED_NOTABLE.getName(this.metricsPrefix), Tags.of(PATH_FAST));
+		recycledNotableSlowPathCounter = this.meterRegistry.counter(RECYCLED_NOTABLE.getName(this.metricsPrefix), Tags.of(PATH_SLOW));
 
-		resourceSummaryLifetime = this.meterRegistry.summary(
-			DocumentedPoolMeters.SUMMARY_LIFETIME.getName(this.metricsPrefix));
-		resourceSummaryIdleness = this.meterRegistry.summary(
-			DocumentedPoolMeters.SUMMARY_IDLENESS.getName(this.metricsPrefix));
+		resourceSummaryLifetime = this.meterRegistry.timer(SUMMARY_LIFETIME.getName(this.metricsPrefix));
+		resourceSummaryIdleness = this.meterRegistry.timer(SUMMARY_IDLENESS.getName(this.metricsPrefix));
 	}
 
 	@Override
@@ -85,12 +78,12 @@ final class MicrometerMetricsRecorder implements PoolMetricsRecorder {
 
 	@Override
 	public void recordResetLatency(long latencyMs) {
-		resetMeter.record(latencyMs);
+		resetMeter.record(latencyMs, TimeUnit.MILLISECONDS);
 	}
 
 	@Override
 	public void recordDestroyLatency(long latencyMs) {
-		destroyedMeter.record(latencyMs);
+		destroyedMeter.record(latencyMs, TimeUnit.MILLISECONDS);
 	}
 
 	@Override
@@ -100,12 +93,12 @@ final class MicrometerMetricsRecorder implements PoolMetricsRecorder {
 
 	@Override
 	public void recordLifetimeDuration(long millisecondsSinceAllocation) {
-		resourceSummaryLifetime.record(millisecondsSinceAllocation);
+		resourceSummaryLifetime.record(millisecondsSinceAllocation, TimeUnit.MILLISECONDS);
 	}
 
 	@Override
 	public void recordIdleTime(long millisecondsIdle) {
-		resourceSummaryIdleness.record(millisecondsIdle);
+		resourceSummaryIdleness.record(millisecondsIdle, TimeUnit.MILLISECONDS);
 	}
 
 	@Override

--- a/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/MicrometerMetricsRecorder.java
+++ b/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/MicrometerMetricsRecorder.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool.introspection.micrometer;
+
+import java.util.concurrent.TimeUnit;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+
+import reactor.pool.PoolMetricsRecorder;
+
+final class MicrometerMetricsRecorder implements PoolMetricsRecorder {
+
+	private final String        metricsPrefix;
+	private final MeterRegistry meterRegistry;
+
+	private final Timer               allocationFailureTimer;
+	private final Timer               allocationSuccessTimer;
+	private final DistributionSummary destroyedMeter;
+	private final Counter             recycledCounter;
+	private final Counter             recycledNotableFastPathCounter;
+	private final Counter             recycledNotableSlowPathCounter;
+	private final DistributionSummary resetMeter;
+	private final DistributionSummary resourceSummaryIdleness;
+	private final DistributionSummary resourceSummaryLifetime;
+
+	MicrometerMetricsRecorder(String metricsPrefix, MeterRegistry registry) {
+		this.metricsPrefix = metricsPrefix;
+		this.meterRegistry = registry;
+
+		allocationSuccessTimer = this.meterRegistry.timer(
+			DocumentedPoolMeters.ALLOCATION.getName(this.metricsPrefix),
+			Tags.of(DocumentedPoolMeters.AllocationTags.OUTCOME_SUCCESS));
+		allocationFailureTimer = this.meterRegistry.timer(
+			DocumentedPoolMeters.ALLOCATION.getName(this.metricsPrefix),
+			Tags.of(DocumentedPoolMeters.AllocationTags.OUTCOME_FAILURE));
+
+		resetMeter = this.meterRegistry.summary(
+			DocumentedPoolMeters.RESET.getName(this.metricsPrefix));
+		destroyedMeter = this.meterRegistry.summary(
+			DocumentedPoolMeters.DESTROYED.getName(this.metricsPrefix));
+
+		recycledCounter = this.meterRegistry.counter(
+			DocumentedPoolMeters.RECYCLED.getName(this.metricsPrefix));
+
+		recycledNotableFastPathCounter = this.meterRegistry.counter(
+			DocumentedPoolMeters.RECYCLED_NOTABLE.getName(this.metricsPrefix),
+			Tags.of(DocumentedPoolMeters.RecycledNotableTags.PATH_FAST));
+		recycledNotableSlowPathCounter = this.meterRegistry.counter(
+			DocumentedPoolMeters.RECYCLED_NOTABLE.getName(this.metricsPrefix),
+			Tags.of(DocumentedPoolMeters.RecycledNotableTags.PATH_SLOW));
+
+		resourceSummaryLifetime = this.meterRegistry.summary(
+			DocumentedPoolMeters.SUMMARY_LIFETIME.getName(this.metricsPrefix));
+		resourceSummaryIdleness = this.meterRegistry.summary(
+			DocumentedPoolMeters.SUMMARY_IDLENESS.getName(this.metricsPrefix));
+	}
+
+	@Override
+	public void recordAllocationSuccessAndLatency(long latencyMs) {
+		allocationSuccessTimer.record(latencyMs, TimeUnit.MILLISECONDS);
+	}
+
+	@Override
+	public void recordAllocationFailureAndLatency(long latencyMs) {
+		allocationFailureTimer.record(latencyMs, TimeUnit.MILLISECONDS);
+	}
+
+	@Override
+	public void recordResetLatency(long latencyMs) {
+		resetMeter.record(latencyMs);
+	}
+
+	@Override
+	public void recordDestroyLatency(long latencyMs) {
+		destroyedMeter.record(latencyMs);
+	}
+
+	@Override
+	public void recordRecycled() {
+		recycledCounter.increment();
+	}
+
+	@Override
+	public void recordLifetimeDuration(long millisecondsSinceAllocation) {
+		resourceSummaryLifetime.record(millisecondsSinceAllocation);
+	}
+
+	@Override
+	public void recordIdleTime(long millisecondsIdle) {
+		resourceSummaryIdleness.record(millisecondsIdle);
+	}
+
+	@Override
+	public void recordSlowPath() {
+		recycledNotableSlowPathCounter.increment();
+	}
+
+	@Override
+	public void recordFastPath() {
+		recycledNotableFastPathCounter.increment();
+	}
+}

--- a/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/MicrometerMetricsRecorder.java
+++ b/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/MicrometerMetricsRecorder.java
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 

--- a/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/PoolGaugesBinder.java
+++ b/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/PoolGaugesBinder.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool.introspection.micrometer;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import reactor.pool.InstrumentedPool;
+import reactor.pool.PoolBuilder;
+
+import static reactor.pool.introspection.micrometer.DocumentedPoolMeters.CommonTags.POOL_NAME;
+
+/**
+ * A {@link MeterBinder} that registers Micrometer gauges around a {@link InstrumentedPool}'s {@link reactor.pool.InstrumentedPool.PoolMetrics},
+ * publishing to the provided {@link MeterRegistry}. One can differentiate between pools thanks to the provided {@code poolName},
+ * which will be set on all meters as the value for the {@link DocumentedPoolMeters.CommonTags#POOL_NAME} tag.
+ * <p>
+ * {@link DocumentedPoolMeters} include the gauges which are:
+ * <ul>
+ *     <li> {@link DocumentedPoolMeters#ACQUIRED} </li>
+ *     <li> {@link DocumentedPoolMeters#ALLOCATED}, </li>
+ *     <li> {@link DocumentedPoolMeters#IDLE} </li>
+ *     <li> {@link DocumentedPoolMeters#PENDING_ACQUIRE} </li>
+ * </ul>
+ * <p>
+ * Note that this doesn't cover metrics that show evolution of the pool's state and timings, which are separately
+ * measured using a {@link reactor.pool.PoolMetricsRecorder} provided when building the pool.
+ * See {@link Micrometer#recorder(String, MeterRegistry)}, as well as {@link Micrometer#instrumentedPool(PoolBuilder, String, MeterRegistry)}
+ * for a solution that covers both.
+ *
+ * @author Simon Baslé
+ */
+public final class PoolGaugesBinder implements MeterBinder {
+
+	private final InstrumentedPool.PoolMetrics poolMetrics;
+	private final String                       poolName;
+
+	/**
+	 * Create a {@link PoolGaugesBinder}.
+	 *
+	 * @param poolMetrics the {@link reactor.pool.InstrumentedPool.PoolMetrics} to turn into gauges
+	 * @param poolName the tag value to use on the gauges to differentiate between pools
+	 * @see DocumentedPoolMeters
+	 */
+	public PoolGaugesBinder(InstrumentedPool.PoolMetrics poolMetrics, String poolName) {
+		this.poolMetrics = poolMetrics;
+		this.poolName = poolName;
+	}
+
+	@Override
+	public void bindTo(MeterRegistry meterRegistry) {
+		Tags nameTag = Tags.of(POOL_NAME.asString(), poolName);
+		Gauge.builder(
+				DocumentedPoolMeters.ACQUIRED.getName(), poolMetrics,
+				InstrumentedPool.PoolMetrics::acquiredSize)
+			.tags(nameTag)
+			.register(meterRegistry);
+		Gauge.builder(
+				DocumentedPoolMeters.ALLOCATED.getName(), poolMetrics,
+				InstrumentedPool.PoolMetrics::allocatedSize)
+			.tags(nameTag)
+			.register(meterRegistry);
+		Gauge.builder(
+				DocumentedPoolMeters.IDLE.getName(), poolMetrics,
+				InstrumentedPool.PoolMetrics::idleSize)
+			.tags(nameTag)
+			.register(meterRegistry);
+		Gauge.builder(
+				DocumentedPoolMeters.PENDING_ACQUIRE.getName(), poolMetrics,
+				InstrumentedPool.PoolMetrics::pendingAcquireSize)
+			.tags(nameTag)
+			.register(meterRegistry);
+	}
+}

--- a/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/package-info.java
+++ b/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Metrics and observability Micrometer utilities for Reactor-Pool.
+ *
+ * @author Simon Baslé
+ */
+@NonNullApi
+package reactor.pool.introspection.micrometer;
+
+import reactor.util.annotation.NonNullApi;

--- a/reactor-pool-micrometer/src/test/java/reactor/pool/introspection/micrometer/MicrometerTest.java
+++ b/reactor-pool-micrometer/src/test/java/reactor/pool/introspection/micrometer/MicrometerTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool.introspection.micrometer;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import reactor.core.publisher.Mono;
+import reactor.pool.InstrumentedPool;
+import reactor.pool.PoolBuilder;
+import reactor.pool.PoolMetricsRecorder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MicrometerTest {
+
+	@Test
+	void metersRegisteredForGauge() {
+		SimpleMeterRegistry r = new SimpleMeterRegistry();
+		InstrumentedPool<String> pool = PoolBuilder.from(Mono.just("testResource")).buildPool();
+		InstrumentedPool.PoolMetrics poolMetrics = pool.metrics();
+
+		Micrometer.gaugesOf(poolMetrics, "testGauge", r);
+
+		assertThat(r.getMeters().stream()
+			.map(m -> {
+				String name = m.getId().getName();
+				String tags = m.getId().getTags().isEmpty() ? "" : String.valueOf(m.getId().getTags());
+				return name + tags;
+			}))
+			.containsExactlyInAnyOrder(
+				"testGauge.resources.acquired",
+				"testGauge.resources.allocated",
+				"testGauge.resources.idle",
+				"testGauge.resources.pendingAcquire"
+			);
+	}
+
+	@Test
+	void metersRegisteredForRecorder() {
+		SimpleMeterRegistry r = new SimpleMeterRegistry();
+
+		PoolMetricsRecorder recorder = Micrometer.recorder("testRecorder", r);
+		InstrumentedPool<String> pool = PoolBuilder.from(Mono.just("testResource"))
+			.metricsRecorder(recorder)
+			.buildPool();
+
+		assertThat(r.getMeters().stream()
+			.map(m -> {
+				String name = m.getId().getName();
+				String tags = m.getId().getTags().isEmpty() ? "" : String.valueOf(m.getId().getTags());
+				return name + tags;
+			}))
+			.containsExactlyInAnyOrder(
+				"testRecorder.allocation[tag(pool.allocation.outcome=success)]",
+				"testRecorder.allocation[tag(pool.allocation.outcome=failure)]",
+				"testRecorder.destroyed",
+				"testRecorder.recycled",
+				"testRecorder.recycled.notable[tag(pool.recycling.path=fast)]",
+				"testRecorder.recycled.notable[tag(pool.recycling.path=slow)]",
+				"testRecorder.reset",
+				"testRecorder.resources.summary.lifetime",
+				"testRecorder.resources.summary.idleness"
+			);
+	}
+
+	@Test
+	void micrometerInstrumentedPoolRegistersGaugeAndRecorderMetrics() {
+		SimpleMeterRegistry r = new SimpleMeterRegistry();
+
+		InstrumentedPool<String> pool = Micrometer.instrumentedPool(PoolBuilder.from(Mono.just("testResource")),
+			"testMetrics", r);
+
+		assertThat(r.getMeters().stream()
+			.map(m -> {
+				String name = m.getId().getName();
+				String tags = m.getId().getTags().isEmpty() ? "" : String.valueOf(m.getId().getTags());
+				return name + tags;
+			}))
+			.containsExactlyInAnyOrder(
+				"testMetrics.resources.acquired",
+				"testMetrics.resources.allocated",
+				"testMetrics.resources.idle",
+				"testMetrics.resources.pendingAcquire",
+				"testMetrics.allocation[tag(pool.allocation.outcome=success)]",
+				"testMetrics.allocation[tag(pool.allocation.outcome=failure)]",
+				"testMetrics.destroyed",
+				"testMetrics.recycled",
+				"testMetrics.recycled.notable[tag(pool.recycling.path=fast)]",
+				"testMetrics.recycled.notable[tag(pool.recycling.path=slow)]",
+				"testMetrics.reset",
+				"testMetrics.resources.summary.lifetime",
+				"testMetrics.resources.summary.idleness"
+			);
+	}
+}

--- a/reactor-pool-micrometer/src/test/java/reactor/pool/introspection/micrometer/MicrometerTest.java
+++ b/reactor-pool-micrometer/src/test/java/reactor/pool/introspection/micrometer/MicrometerTest.java
@@ -43,10 +43,10 @@ class MicrometerTest {
 				return name + tags;
 			}))
 			.containsExactlyInAnyOrder(
-				"testGauge.resources.acquired",
-				"testGauge.resources.allocated",
-				"testGauge.resources.idle",
-				"testGauge.resources.pendingAcquire"
+				"reactor.pool.resources.acquired[tag(pool.name=testGauge)]",
+				"reactor.pool.resources.allocated[tag(pool.name=testGauge)]",
+				"reactor.pool.resources.idle[tag(pool.name=testGauge)]",
+				"reactor.pool.resources.pendingAcquire[tag(pool.name=testGauge)]"
 			);
 	}
 
@@ -66,15 +66,15 @@ class MicrometerTest {
 				return name + tags;
 			}))
 			.containsExactlyInAnyOrder(
-				"testRecorder.allocation[tag(pool.allocation.outcome=success)]",
-				"testRecorder.allocation[tag(pool.allocation.outcome=failure)]",
-				"testRecorder.destroyed",
-				"testRecorder.recycled",
-				"testRecorder.recycled.notable[tag(pool.recycling.path=fast)]",
-				"testRecorder.recycled.notable[tag(pool.recycling.path=slow)]",
-				"testRecorder.reset",
-				"testRecorder.resources.summary.lifetime",
-				"testRecorder.resources.summary.idleness"
+				"reactor.pool.allocation[tag(pool.allocation.outcome=success), tag(pool.name=testRecorder)]",
+				"reactor.pool.allocation[tag(pool.allocation.outcome=failure), tag(pool.name=testRecorder)]",
+				"reactor.pool.destroyed[tag(pool.name=testRecorder)]",
+				"reactor.pool.recycled[tag(pool.name=testRecorder)]",
+				"reactor.pool.recycled.notable[tag(pool.name=testRecorder), tag(pool.recycling.path=fast)]",
+				"reactor.pool.recycled.notable[tag(pool.name=testRecorder), tag(pool.recycling.path=slow)]",
+				"reactor.pool.reset[tag(pool.name=testRecorder)]",
+				"reactor.pool.resources.summary.lifetime[tag(pool.name=testRecorder)]",
+				"reactor.pool.resources.summary.idleness[tag(pool.name=testRecorder)]"
 			);
 	}
 
@@ -92,19 +92,19 @@ class MicrometerTest {
 				return name + tags;
 			}))
 			.containsExactlyInAnyOrder(
-				"testMetrics.resources.acquired",
-				"testMetrics.resources.allocated",
-				"testMetrics.resources.idle",
-				"testMetrics.resources.pendingAcquire",
-				"testMetrics.allocation[tag(pool.allocation.outcome=success)]",
-				"testMetrics.allocation[tag(pool.allocation.outcome=failure)]",
-				"testMetrics.destroyed",
-				"testMetrics.recycled",
-				"testMetrics.recycled.notable[tag(pool.recycling.path=fast)]",
-				"testMetrics.recycled.notable[tag(pool.recycling.path=slow)]",
-				"testMetrics.reset",
-				"testMetrics.resources.summary.lifetime",
-				"testMetrics.resources.summary.idleness"
+				"reactor.pool.resources.acquired[tag(pool.name=testMetrics)]",
+				"reactor.pool.resources.allocated[tag(pool.name=testMetrics)]",
+				"reactor.pool.resources.idle[tag(pool.name=testMetrics)]",
+				"reactor.pool.resources.pendingAcquire[tag(pool.name=testMetrics)]",
+				"reactor.pool.allocation[tag(pool.allocation.outcome=success), tag(pool.name=testMetrics)]",
+				"reactor.pool.allocation[tag(pool.allocation.outcome=failure), tag(pool.name=testMetrics)]",
+				"reactor.pool.destroyed[tag(pool.name=testMetrics)]",
+				"reactor.pool.recycled[tag(pool.name=testMetrics)]",
+				"reactor.pool.recycled.notable[tag(pool.name=testMetrics), tag(pool.recycling.path=fast)]",
+				"reactor.pool.recycled.notable[tag(pool.name=testMetrics), tag(pool.recycling.path=slow)]",
+				"reactor.pool.reset[tag(pool.name=testMetrics)]",
+				"reactor.pool.resources.summary.lifetime[tag(pool.name=testMetrics)]",
+				"reactor.pool.resources.summary.idleness[tag(pool.name=testMetrics)]"
 			);
 	}
 }

--- a/reactor-pool/build.gradle
+++ b/reactor-pool/build.gradle
@@ -23,6 +23,7 @@ description = 'Reactor Generic Object Pooling'
 
 ext {
 	shortName = 'Reactor Pool'
+	osgiVersion = osgiVersion(version.toString())
 	bndOptions = [
 		"Export-Package": [
 			"!*internal*",

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,3 +17,4 @@
 rootProject.name = 'reactor-pool-base'
 
 include 'reactor-pool'
+include 'reactor-pool-micrometer'


### PR DESCRIPTION
This commit adds a new module depending directly on Micrometer which
provides out-of-the-box implementations of PoolMetricsRecorder and other
utilities to instrument a Pool with Micrometer.

Fixes #161.
