### PR TITLE
Use new gha API for setting output, latest core actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,18 @@ jobs:
     name: checks
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
       with:
         fetch-depth: 0 # for spotless
-    - uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # renovate: tag=v2
+    - uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc # tag=v3
       with:
         distribution: 'temurin'
         java-version: 8
-    - uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7 # renovate: tag=v2
+    - uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # tag=v2
       name: license header check
       with:
         arguments: spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
-    - uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7 # renovate: tag=v2
+    - uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef # tag=v2
       name: gradle
       with:
         arguments: check javadoc

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,9 @@ jobs:
       versionType: ${{ steps.version.outputs.versionType }}
       fullVersion: ${{ steps.version.outputs.fullVersion }}
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
       - name: setup java
-        uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # renovate: tag=v2
+        uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc # tag=v3
         with:
           distribution: 'temurin'
           java-version: 8
@@ -39,9 +39,9 @@ jobs:
     name: slowChecks
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
       - name: setup java
-        uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # renovate: tag=v2
+        uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc # tag=v3
         with:
           distribution: 'temurin'
           java-version: 8
@@ -57,8 +57,8 @@ jobs:
     if: needs.prepare.outputs.versionType == 'SNAPSHOT'
     environment: snapshots
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2
-      - uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # renovate: tag=v2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
+      - uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc # tag=v3
         with:
           distribution: 'temurin'
           java-version: 8
@@ -77,8 +77,8 @@ jobs:
     if: needs.prepare.outputs.versionType == 'MILESTONE'
     environment: releases
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2
-      - uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # renovate: tag=v2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
+      - uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc # tag=v3
         with:
           distribution: 'temurin'
           java-version: 8
@@ -99,8 +99,8 @@ jobs:
     if: needs.prepare.outputs.versionType == 'RELEASE'
     environment: releases
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2
-      - uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # renovate: tag=v2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
+      - uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc # tag=v3
         with:
           distribution: 'temurin'
           java-version: 8
@@ -122,7 +122,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
       - name: tag
         run: |
           git config --local user.name 'reactorbot'
@@ -136,7 +136,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
       - name: tag
         run: |
           git config --local user.name 'reactorbot'

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -65,17 +65,39 @@ ext {
 	}
 }
 
+static def outputToGha(String versionType, String fullVersion) {
+	def ghaFilename = System.getenv("GITHUB_OUTPUT")
+	if (ghaFilename == null) {
+		println "::set-output name=versionType::$versionType"
+		println "::set-output name=fullVersion::$fullVersion"
+	}
+	else {
+		println "using GITHUB_OUTPUT file"
+		def ghaFile = new File(ghaFilename)
+		ghaFile.withWriterAppend {
+			it.newLine()
+			it.append("versionType=$versionType")
+			it.newLine()
+			it.append("fullVersion=$fullVersion")
+		}
+	}
+}
+
 task qualifyVersionGha() {
 	doLast {
 		def versionType = qualifyVersion("$version")
-
-		println "::set-output name=versionType::$versionType"
-		println "::set-output name=fullVersion::$version"
+		//we ensure that if at least _one_ submodule version is BAD, we only output versionType=BAD + job fails
 		if (versionType == "BAD") {
+			outputToGha(versionType, version)
 			println "::error ::Unable to parse $version to a VersionNumber with recognizable qualifier"
 			throw new TaskExecutionException(tasks.getByName("qualifyVersionGha"), new IllegalArgumentException("Unable to parse $version to a VersionNumber with recognizable qualifier"))
 		}
 		println "Recognized $version as $versionType"
+
+		//only output the versionType and fullVersion for the main artifact
+		if (project.name == 'reactor-pool') {
+			outputToGha(versionType, version)
+		}
 	}
 }
 


### PR DESCRIPTION
This commit changes the way job output is defined, using the new way of
a GITHUB_OUTPUT file environment variable.

The old way of echoing strings is deprecated for sensitive elements,
including action/job output.

It also reorders the output in order to:

• ensure BAD version is detected before any output and fails the job
• ensure only one version/versionType is outputted when there are
multiple modules (here, the `reactor-pool` one)

Finally it updates core and gradle actions to latest versions.
This fixes warnings about deprecated output style and deprecated Node
version being still in use by these actions.

See reactor/reactor#727.