### PR TITLE
Expose metrics for `pending acquire` operation latency

### DIFF
--- a/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/PoolMetersDocumentation.java
+++ b/reactor-pool-micrometer/src/main/java/reactor/pool/introspection/micrometer/PoolMetersDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import io.micrometer.core.instrument.docs.MeterDocumentation;
  * Meters used by {@link Micrometer} utility.
  *
  * @author Simon Baslé
+ * @author Violeta Georgieva
  */
 enum PoolMetersDocumentation implements MeterDocumentation {
 
@@ -210,6 +211,23 @@ enum PoolMetersDocumentation implements MeterDocumentation {
 		public KeyName[] getKeyNames() {
 			return CommonTags.values();
 		}
+	},
+
+	PENDING {
+		@Override
+		public String getName() {
+			return "reactor.pool.pending";
+		}
+
+		@Override
+		public Meter.Type getType() {
+			return Meter.Type.TIMER;
+		}
+
+		@Override
+		public KeyName[] getKeyNames() {
+			return KeyName.merge(CommonTags.values(), PendingTags.values());
+		}
 	};
 
 	public enum AllocationTags implements KeyName {
@@ -256,5 +274,24 @@ enum PoolMetersDocumentation implements MeterDocumentation {
 				return "pool.name";
 			}
 		}
+	}
+
+	public enum PendingTags implements KeyName {
+
+		/**
+		 * Indicates whether the pending acquire operation finished with a {@code success} or {@code failure} i.e.
+		 * whether an allocation operation was triggered or a {@link reactor.pool.PoolAcquireTimeoutException}
+		 * was thrown.
+		 */
+		OUTCOME {
+			@Override
+			public String asString() {
+				return "pool.pending.outcome";
+			}
+		};
+
+		public static final Tag OUTCOME_SUCCESS = Tag.of(OUTCOME.asString(), "success");
+		public static final Tag OUTCOME_FAILURE = Tag.of(OUTCOME.asString(), "failure");
+
 	}
 }

--- a/reactor-pool-micrometer/src/test/java/reactor/pool/introspection/micrometer/MicrometerTest.java
+++ b/reactor-pool-micrometer/src/test/java/reactor/pool/introspection/micrometer/MicrometerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,9 @@ class MicrometerTest {
 				"reactor.pool.recycled.notable[tag(pool.name=testRecorder), tag(pool.recycling.path=slow)]",
 				"reactor.pool.reset[tag(pool.name=testRecorder)]",
 				"reactor.pool.resources.summary.lifetime[tag(pool.name=testRecorder)]",
-				"reactor.pool.resources.summary.idleness[tag(pool.name=testRecorder)]"
+				"reactor.pool.resources.summary.idleness[tag(pool.name=testRecorder)]",
+				"reactor.pool.pending[tag(pool.name=testRecorder), tag(pool.pending.outcome=success)]",
+				"reactor.pool.pending[tag(pool.name=testRecorder), tag(pool.pending.outcome=failure)]"
 			);
 	}
 
@@ -104,7 +106,9 @@ class MicrometerTest {
 				"reactor.pool.recycled.notable[tag(pool.name=testMetrics), tag(pool.recycling.path=slow)]",
 				"reactor.pool.reset[tag(pool.name=testMetrics)]",
 				"reactor.pool.resources.summary.lifetime[tag(pool.name=testMetrics)]",
-				"reactor.pool.resources.summary.idleness[tag(pool.name=testMetrics)]"
+				"reactor.pool.resources.summary.idleness[tag(pool.name=testMetrics)]",
+				"reactor.pool.pending[tag(pool.name=testMetrics), tag(pool.pending.outcome=success)]",
+				"reactor.pool.pending[tag(pool.name=testMetrics), tag(pool.pending.outcome=failure)]"
 			);
 	}
 }

--- a/reactor-pool/src/main/java/reactor/pool/AbstractPool.java
+++ b/reactor-pool/src/main/java/reactor/pool/AbstractPool.java
@@ -413,7 +413,7 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
 		public void run() {
 			if (Borrower.this.compareAndSet(false, true)) {
 				// this is failure, a timeout was observed
-				pool.metricsRecorder.recordPendingFailureAndLatency(pool.clock.millis() - pendingAcquireStart);
+				stopPendingCountdown(false);
 				pool.cancelAcquire(Borrower.this);
 				actual.onError(new PoolAcquireTimeoutException(pendingAcquireTimeout));
 			}

--- a/reactor-pool/src/main/java/reactor/pool/NoOpPoolMetricsRecorder.java
+++ b/reactor-pool/src/main/java/reactor/pool/NoOpPoolMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ package reactor.pool;
  * A No-Op {@link PoolMetricsRecorder} that can be used as a default if instrumentation is not desired.
  *
  * @author Simon Baslé
+ * @author Violeta Georgieva
  */
 final class NoOpPoolMetricsRecorder implements PoolMetricsRecorder {
 
@@ -71,6 +72,16 @@ final class NoOpPoolMetricsRecorder implements PoolMetricsRecorder {
 
     @Override
     public void recordFastPath() {
+
+    }
+
+    @Override
+    public void recordPendingSuccessAndLatency(long latencyMs) {
+
+    }
+
+    @Override
+    public void recordPendingFailureAndLatency(long latencyMs) {
 
     }
 }

--- a/reactor-pool/src/main/java/reactor/pool/PoolMetricsRecorder.java
+++ b/reactor-pool/src/main/java/reactor/pool/PoolMetricsRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ package reactor.pool;
  * responsibility of a {@link java.time.Clock}.
  *
  * @author Simon Baslé
+ * @author Violeta Georgieva
  */
 public interface PoolMetricsRecorder {
 
@@ -77,4 +78,26 @@ public interface PoolMetricsRecorder {
 	 * Record the fact that a {@link Pool} has a fast path of recycling and just used it.
 	 */
 	void recordFastPath();
+
+	/**
+	 * Record a latency for successful pending acquire operation.
+	 * A successful pending acquire operation is such that triggers an allocation operation.
+	 * Implies incrementing a pending acquire success counter as well.
+	 * @param latencyMs the latency in milliseconds
+	 * @since 1.0.4
+	 */
+	default void recordPendingSuccessAndLatency(long latencyMs) {
+		// noop
+	}
+
+	/**
+	 * Record a latency for failed pending acquire.
+	 * A failed pending acquire operation is such that finishes with {@link PoolAcquireTimeoutException}.
+	 * Implies incrementing a pending acquire failure counter as well.
+	 * @param latencyMs the latency in milliseconds
+	 * @since 1.0.4
+	 */
+	default void recordPendingFailureAndLatency(long latencyMs) {
+		// noop
+	}
 }

--- a/reactor-pool/src/main/java/reactor/pool/SimpleDequePool.java
+++ b/reactor-pool/src/main/java/reactor/pool/SimpleDequePool.java
@@ -366,7 +366,7 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 						borrower.fail(new PoolShutdownException());
 						return;
 					}
-					borrower.stopPendingCountdown();
+					borrower.stopPendingCountdown(true);
 					ACQUIRED.incrementAndGet(this);
 					poolConfig.acquisitionScheduler()
 					          .schedule(() -> borrower.deliver(slot));
@@ -412,7 +412,7 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 							borrower.fail(new PoolShutdownException());
 							return;
 						}
-						borrower.stopPendingCountdown();
+						borrower.stopPendingCountdown(true);
 						long start = clock.millis();
 						Mono<POOLABLE> allocator = allocatorWithScheduler();
 

--- a/reactor-pool/src/test/java/reactor/pool/CommonPoolTest.java
+++ b/reactor-pool/src/test/java/reactor/pool/CommonPoolTest.java
@@ -2693,15 +2693,18 @@ public class CommonPoolTest {
 				.clock(recorder.getClock());
 		Pool<String> pool = configAdjuster.apply(builder);
 
-		PooledRef<String> pooledRef = pool.acquire(Duration.ofMillis(1)).block(Duration.ofSeconds(1)); //success
+		//success, acquisition happens immediately
+		PooledRef<String> pooledRef = pool.acquire(Duration.ofMillis(1)).block(Duration.ofSeconds(1));
 		assertThat(pooledRef).isNotNull();
 
-		pool.acquire(Duration.ofMillis(50)).subscribe(); //success
+		//success, acquisition happens after pending some time
+		pool.acquire(Duration.ofMillis(50)).subscribe();
 
+		//error, timed out
 		pool.acquire(Duration.ofMillis(1))
 				.as(StepVerifier::create)
 				.expectError(PoolAcquireTimeoutException.class)
-				.verify(Duration.ofSeconds(1)); //error
+				.verify(Duration.ofSeconds(1));
 
 		pooledRef.release().block(Duration.ofSeconds(1));
 


### PR DESCRIPTION
This is related to https://github.com/reactor/reactor-netty/issues/2946