### PR TITLE
Concurrent Reactor Pools

### DIFF
--- a/reactor-pool/build.gradle
+++ b/reactor-pool/build.gradle
@@ -127,6 +127,7 @@ task japicmp(type: JapicmpTask) {
 	classExcludes = [
 	]
 	methodExcludes = [
+			"reactor.pool.decorators.InstrumentedPoolDecorators#concurrentPools(int, org.reactivestreams.Publisher, java.util.function.Function)"
 	]
 }
 check.dependsOn japicmp

--- a/reactor-pool/src/main/java/reactor/pool/AbstractPool.java
+++ b/reactor-pool/src/main/java/reactor/pool/AbstractPool.java
@@ -22,6 +22,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import org.reactivestreams.Publisher;
@@ -390,7 +391,7 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
 		static final Disposable TIMEOUT_DISPOSED = Disposables.disposed();
 
 		final CoreSubscriber<? super AbstractPooledRef<POOLABLE>> actual;
-		final AbstractPool<POOLABLE> pool;
+		final AtomicReference<AbstractPool<POOLABLE>> pool;
 		final Duration pendingAcquireTimeout;
 
 		long pendingAcquireStart;
@@ -400,7 +401,7 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
 				AbstractPool<POOLABLE> pool,
 				Duration pendingAcquireTimeout) {
 			this.actual = actual;
-			this.pool = pool;
+			this.pool = new AtomicReference<>(pool);
 			this.pendingAcquireTimeout = pendingAcquireTimeout;
 			this.timeoutTask = TIMEOUT_DISPOSED;
 		}
@@ -414,7 +415,7 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
 			if (Borrower.this.compareAndSet(false, true)) {
 				// this is failure, a timeout was observed
 				stopPendingCountdown(false);
-				pool.cancelAcquire(Borrower.this);
+				pool().cancelAcquire(Borrower.this);
 				actual.onError(new PoolAcquireTimeoutException(pendingAcquireTimeout));
 			}
 		}
@@ -423,7 +424,7 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
 		public void request(long n) {
 			if (Operators.validate(n)) {
 				// doAcquire will check for acquire timeout
-				pool.doAcquire(this);
+				pool().doAcquire(this);
 			}
 		}
 
@@ -432,6 +433,7 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
 		 */
 		void stopPendingCountdown(boolean success) {
 			if (pendingAcquireStart > 0) {
+				AbstractPool<POOLABLE> pool = pool();
 				if (success) {
 					pool.metricsRecorder.recordPendingSuccessAndLatency(pool.clock.millis() - pendingAcquireStart);
 				} else {
@@ -446,7 +448,7 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
 		@Override
 		public void cancel() {
 			set(true);
-			pool.cancelAcquire(this);
+			pool().cancelAcquire(this);
 			stopPendingCountdown(true); // this is not failure, the subscription was canceled
 		}
 
@@ -484,6 +486,14 @@ abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
 		@Override
 		public String toString() {
 			return get() ? "Borrower(cancelled)" : "Borrower";
+		}
+
+		AbstractPool<POOLABLE> pool() {
+			return pool.get();
+		}
+
+		void setPool(AbstractPool<POOLABLE> replace) {
+			pool.set(replace);
 		}
 	}
 

--- a/reactor-pool/src/main/java/reactor/pool/InstrumentedPool.java
+++ b/reactor-pool/src/main/java/reactor/pool/InstrumentedPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,16 @@ public interface InstrumentedPool<POOLABLE> extends Pool<POOLABLE> {
 	 * @return a {@link PoolMetrics} object to be used to get live gauges about the {@link Pool}
 	 */
 	PoolMetrics metrics();
+
+	/**
+	 * Estimates if the pool can currently either reuse or create some resources
+	 * @return true if the pool can currently either reuse or create some resources, false if no idles resources are
+	 *         currently available and no more resources can be currently created.
+	 */
+	default boolean hasAvailableResources() {
+		PoolMetrics pm = metrics();
+		return (pm.idleSize() + config().allocationStrategy().estimatePermitCount()) - pm.pendingAcquireSize() >= 0;
+	}
 
 	/**
 	 * An object that can be used to get live information about a {@link Pool}, suitable

--- a/reactor-pool/src/main/java/reactor/pool/Pool.java
+++ b/reactor-pool/src/main/java/reactor/pool/Pool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -178,4 +178,14 @@ public interface Pool<POOLABLE> extends Disposable {
 	 * @return a Mono triggering the shutdown of the pool once subscribed.
 	 */
 	Mono<Void> disposeLater();
+
+	/**
+	 * Transfer some pending borrowers from another pool into this pool.
+	 *
+	 * @param from another pool to steal resources from
+	 * @return true if some borrowers have been moved from <code>from</code> into this pool instance
+	 */
+	default boolean transferBorrowersFrom(InstrumentedPool<POOLABLE> from) {
+		return false;
+	}
 }

--- a/reactor-pool/src/main/java/reactor/pool/PoolBuilder.java
+++ b/reactor-pool/src/main/java/reactor/pool/PoolBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,8 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
 	PoolMetricsRecorder                    metricsRecorder             = NoOpPoolMetricsRecorder.INSTANCE;
 	boolean                                idleLruOrder         = true;
 	BiFunction<Runnable, Duration, Disposable> pendingAcquireTimer = DEFAULT_PENDING_ACQUIRE_TIMER;
+
+	ResourceManager resourceManager = DEFAULT_RESOURCE_MANAGER;
 
 	PoolBuilder(Mono<T> allocator, Function<PoolConfig<T>, CONF> configModifier) {
 		this.allocator = allocator;
@@ -445,6 +447,11 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
 		return this;
 	}
 
+	public PoolBuilder<T, CONF> resourceManager(ResourceManager resourceManager) {
+		this.resourceManager = resourceManager;
+		return this;
+	}
+
 	/**
 	 * Add implementation-specific configuration, changing the type of {@link PoolConfig}
 	 * passed to the {@link Pool} factory in {@link #build(Function)}.
@@ -508,7 +515,8 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
 				acquisitionScheduler,
 				metricsRecorder,
 				clock,
-				idleLruOrder);
+				idleLruOrder,
+				resourceManager);
 
 		return this.configModifier.apply(baseConfig);
 	}
@@ -531,4 +539,6 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
 	static final BiPredicate<?, ?>       NEVER_PREDICATE = (ignored1, ignored2) -> false;
 	static final BiFunction<Runnable, Duration, Disposable> DEFAULT_PENDING_ACQUIRE_TIMER = (r, d) -> Schedulers.parallel().schedule(r, d.toNanos(), TimeUnit.NANOSECONDS);
 	static final int DEFAULT_WARMUP_PARALLELISM = 1;
+
+	static final ResourceManager DEFAULT_RESOURCE_MANAGER = () -> {};
 }

--- a/reactor-pool/src/main/java/reactor/pool/PoolConfig.java
+++ b/reactor-pool/src/main/java/reactor/pool/PoolConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2024 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,6 +139,10 @@ public interface PoolConfig<POOLABLE> {
 	 */
 	default BiFunction<Runnable, Duration, Disposable> pendingAcquireTimer() {
 		return PoolBuilder.DEFAULT_PENDING_ACQUIRE_TIMER;
+	}
+
+	default ResourceManager resourceManager() {
+		return PoolBuilder.DEFAULT_RESOURCE_MANAGER;
 	}
 
 }

--- a/reactor-pool/src/main/java/reactor/pool/PoolScheduler.java
+++ b/reactor-pool/src/main/java/reactor/pool/PoolScheduler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool;
+
+import java.util.List;
+
+/**
+ * A Pool that can schedule resource acquisition among multiple sub pools,
+ * each managing a portion of resources. Resource acquisitions will
+ * be concurrently distributed across sub pools using sub pool executors, in a work stealing style.
+ */
+public interface PoolScheduler<T> extends InstrumentedPool<T> {
+    /**
+     * Get the number of borrowers steal count (only if the Scheduler supports work stealing).
+     *
+     * @return the number of Pool steal count, or -1
+     */
+    long stealCount();
+
+    /**
+     * Returns the number of sub pools managed this this scheduler.
+     * @return the number of sub pools managed this this scheduler
+     */
+    List<InstrumentedPool<T>> getPools();
+}

--- a/reactor-pool/src/main/java/reactor/pool/ResourceManager.java
+++ b/reactor-pool/src/main/java/reactor/pool/ResourceManager.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool;
+
+/**
+ * A resource manager utilized by concrete Pool implementations. This manager enables Pools to interact
+ * with its pool scheduler, if there is one enabled.
+ * Pools can access their resource manager via the {@link PoolConfig#resourceManager()} method.
+ */
+public interface ResourceManager {
+    /**
+     * Notifies the pool scheduler that some resources can be acquired from the current pool because either certain
+     * resources are currently estimated to be idle or available for allocation.
+     */
+    void resourceAvailable();
+}

--- a/reactor-pool/src/main/java/reactor/pool/decorators/WorkStealingPool.java
+++ b/reactor-pool/src/main/java/reactor/pool/decorators/WorkStealingPool.java
@@ -1,0 +1,694 @@
+/*
+ * Copyright (c) 2024 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool.decorators;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.pool.*;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+import reactor.util.function.Tuple2;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Function;
+import java.util.function.IntPredicate;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * The WorkStealingPool class represents a scheduler of instrumented pools, with acquisition task stealing
+ * and borrower stealing between pools. It is suitable for scenarios where acquisition tasks
+ * can be distributed among multiple executors to maximize throughput and resource utilization, while preventing the
+ * SimpleDequeueLoop drainLoop method being run forever under very high load from a single thread when there are
+ * permanently hundreds of thousands of active borrowers.
+ * <p>
+ * Each pool is assigned to a unique executor, that is not shared among pools.
+ * <p>
+ * When a resource is acquired:
+ * <ul>
+ *     <li>a random pool is selected like this: if the current thread is one of the pool executors, then the current pool
+ *     of the current thread is selected. Else, a random pool is selected.
+ *     <li>once a pool is selected, the acquisition is then scheduled in the associated (uniq, not shared) pool executor
+ *     </li>
+ *     <li>when an executor has finished to handle its acquisition tasks, it tries to steal pending borrowers from other
+ *     pools, then if it still can acquire some resources, it also tries to steal pending acquisition taskss from any
+ *     other pools</li>
+ * </ul>
+ * <p>
+ * Unlike the ForkJoinPool, this class doesn't create any daemon threads, it is up to
+ * you to provide an Executor for each pool instance (one single executor must be solely assigned to a single pool).
+ */
+final class WorkStealingPool<T> implements PoolScheduler<T>, InstrumentedPool.PoolMetrics {
+    private static final Logger log = Loggers.getLogger(WorkStealingPool.class);
+
+    private final Worker<T>[] workers;
+
+    private final InstrumentedPool<T>[] pools;
+
+    private final ThreadLocal<Worker<T>> currentWorker = ThreadLocal.withInitial(() -> null);
+
+    private final LongAdder stealCount = new LongAdder();
+
+    /**
+     * Pools which can be signaled because they can acquire some resources so they can steal
+     * some borrowers from other pools
+     */
+    private final AtomicBitSet signalablePools;
+
+    /**
+     * Pools which may have some pending borrowers to steal
+     */
+    private final AtomicBitSet pendingBorrowerPools;
+
+    /**
+     * Workers which may have some pending acquisition tasks to steal
+     */
+    private final AtomicBitSet pendingTaskPools;
+
+    @SuppressWarnings("unchecked")
+    WorkStealingPool(int size, Function<ResourceManager, Tuple2<InstrumentedPool<T>, Executor>> poolFactory) {
+        this.signalablePools = new AtomicBitSet(size);
+        this.pendingBorrowerPools = new AtomicBitSet(size);
+        this.pendingTaskPools = new AtomicBitSet(size);
+
+        this.workers = IntStream.range(0, size)
+                .peek(signalablePools::set)
+                .mapToObj(i -> new Worker<>(size, this, i, poolFactory))
+                .peek(worker -> worker.exec.execute(() -> currentWorker.set(worker)))
+                .toArray(Worker[]::new);
+
+        this.pools = Stream.of(workers)
+                .map(Worker::pool)
+                .toArray(InstrumentedPool[]::new);
+    }
+
+    @Override
+    public String toString() {
+        return "[steals=" + stealCount() + "]";
+    }
+
+    public Mono<PooledRef<T>> acquire() {
+        return acquire(Duration.ZERO);
+    }
+
+    public Mono<PooledRef<T>> acquire(Duration timeout) {
+        return Mono.create(sink -> execute(pool -> pool.acquire(timeout).subscribe(sink::success, sink::error)));
+    }
+
+    public Mono<Integer> warmup() {
+        AtomicInteger remaining = new AtomicInteger(pools.length);
+        AtomicInteger count = new AtomicInteger();
+        return Mono.create(sink ->
+                Stream.of(pools).forEach(pool -> pool.warmup().subscribe(result -> {
+                    count.addAndGet(result);
+                    if (remaining.decrementAndGet() == 0) {
+                        sink.success(count.get());
+                    }
+                })));
+    }
+
+    public PoolConfig<T> config() {
+        // TODO there is no config currently for this pool decorator, so what config to return ?
+        // FIXME For now, return the config of the first pool, that's probably not a good thing.
+        return pools[0].config();
+    }
+
+    public Mono<Void> disposeLater() {
+        // Create a Flux of Mono<Void> from disposeLater() of each Pool
+        Flux<Mono<Void>> disposables = Flux.fromArray(pools)
+                .map(Pool::disposeLater);
+
+        // Wait for all disposables to complete
+        return Flux.merge(disposables).then();
+    }
+
+    public PoolMetrics metrics() {
+        return this;
+    }
+
+    // Metrics (TODO should be reworked using shared LongAdders ...)
+
+    @Override
+    public int acquiredSize() {
+        return Stream.of(pools).mapToInt(p -> p.metrics().acquiredSize()).sum();
+    }
+
+    @Override
+    public int allocatedSize() {
+        return Stream.of(pools).mapToInt(p -> p.metrics().allocatedSize()).sum();
+    }
+
+    @Override
+    public int idleSize() {
+        return Stream.of(pools).mapToInt(p -> p.metrics().idleSize()).sum();
+    }
+
+    @Override
+    public int pendingAcquireSize() {
+        return Stream.of(pools).mapToInt(p -> p.metrics().pendingAcquireSize()).sum();
+    }
+
+    @Override
+    public long secondsSinceLastInteraction() {
+        return Stream.of(pools).mapToLong(p -> p.metrics().secondsSinceLastInteraction()).sum();
+    }
+
+    @Override
+    public int getMaxAllocatedSize() {
+        return Stream.of(pools).mapToInt(p -> p.metrics().getMaxAllocatedSize()).max().orElse(0);
+    }
+
+    @Override
+    public int getMaxPendingAcquireSize() {
+        return Stream.of(pools).mapToInt(p -> p.metrics().getMaxPendingAcquireSize()).sum();
+    }
+
+    @Override
+    public boolean isInactiveForMoreThan(Duration duration) {
+        for (InstrumentedPool<T> pool : pools) {
+            if (pool.metrics().isInactiveForMoreThan(duration)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public List<InstrumentedPool<T>> getPools() {
+        return Collections.unmodifiableList(Arrays.asList(pools));
+    }
+
+    @Override
+    public long stealCount() {
+        return stealCount.sum();
+    }
+
+    private void execute(Task<T> task) {
+        Worker<T> currWorker = currentWorker.get();
+        Worker<T> worker = currWorker == null ? nextWorker() : currWorker;
+        worker.execute(task);
+    }
+
+    private Worker<T> nextWorker() {
+        int index = ThreadLocalRandom.current().nextInt(workers.length);
+        return workers[index];
+    }
+
+    private interface Task<T> {
+        void run(InstrumentedPool<T> context);
+    }
+
+    private static final class SignalWork<T> implements Task<T> {
+        static final SignalWork INSTANCE = new SignalWork();
+
+        @Override
+        public void run(InstrumentedPool<T> ctx) {
+        }
+    }
+
+    private static final class Worker<T> implements Runnable, ResourceManager {
+        final WorkStealingPool<T> workStealingPool;
+
+        final AtomicInteger tasksScheduled = new AtomicInteger();
+
+        final ConcurrentLinkedDeque<Task<T>> queue;
+
+        final int workerIndex;
+
+        final InstrumentedPool<T> pool;
+
+        final Executor exec;
+
+        final AtomicInteger signals = new AtomicInteger();
+
+        ThreadLocalRandom rnd;
+
+        final int[] tempWorkerIndexes; // temp array used to get random pos of worker indexes
+
+        public Worker(int subpools, WorkStealingPool<T> workStealingPool, int workerIndex, Function<ResourceManager, Tuple2<InstrumentedPool<T>, Executor>> poolFactory) {
+            this.workStealingPool = workStealingPool;
+            this.workerIndex = workerIndex;
+            this.queue = new ConcurrentLinkedDeque<>();
+            Tuple2<InstrumentedPool<T>, Executor> tuple = poolFactory.apply(this);
+            this.pool = tuple.getT1();
+            this.exec = tuple.getT2();
+            this.tempWorkerIndexes = new int[subpools];
+        }
+
+        InstrumentedPool<T> pool() {
+            return pool;
+        }
+
+        void execute(Task<T> task) {
+            queue.add(task);
+            if (tasksScheduled.getAndIncrement() == 0) {
+                workStealingPool.pendingTaskPools.set(workerIndex);
+                exec.execute(this);
+            }
+        }
+
+        @Override
+        public void run() {
+            ConcurrentLinkedDeque<Task<T>> queue = this.queue;
+            AtomicInteger tasksScheduled = this.tasksScheduled;
+            AtomicInteger signals = this.signals;
+            int currentSignals = -1;
+            boolean canAcquire;
+
+            try {
+                Task<T> task;
+
+                if (rnd == null) {
+                    rnd = ThreadLocalRandom.current();
+                }
+
+                do {
+                    task = queue.poll();
+                    if ((task instanceof SignalWork)) {
+                        continue;
+                    }
+                    // if task is null, it means it has been stolen
+                    if (task != null) {
+                        signalAny(index -> index != workerIndex);
+                        runTask(task);
+                    }
+                } while (tasksScheduled.decrementAndGet() > 0);
+
+                // Get a snapshot of the current signals count, because we don't want to miss any signals while we are stealing
+                currentSignals = signals.get();
+
+                // No more acquisition tasks available, remove our worker index from the pendingTaskPools bitset.
+                workStealingPool.pendingTaskPools.unset(workerIndex);
+
+                // steal other pools, if we can acquire.
+                if (canAcquire = pool.hasAvailableResources()) {
+                    // We can acquire more resources, set ourself as signalable
+                    workStealingPool.signalablePools.set(workerIndex);
+
+                    // And start stealing pending borrowers from other pools
+                    if (canAcquire = stealPendingBorrowers()) {
+                        // If we can still acquire more resources, steal acquisition tasks from other pools
+                        canAcquire = stealPendingTasks();
+                    }
+                }
+
+                if (canAcquire) {
+                    // We can currently acquire more resources, register this worker in the set of signalable workers
+                    workStealingPool.signalablePools.set(workerIndex);
+                    // We don't have any pending borrowers, make sure we are not registered in the set of pending pools
+                    workStealingPool.pendingBorrowerPools.unset(workerIndex);
+                } else {
+                    // Can't currently acquire more resources, remove this worker from set of signalable workers.
+                    workStealingPool.signalablePools.unset(workerIndex);
+                    // We do have pendings, register this worker in the set of pending pools, so others can steal us
+                    workStealingPool.pendingBorrowerPools.set(workerIndex);
+                    // And signal another signalable worker
+                    signalAny(index -> index != workerIndex);
+                }
+            } catch (Exception e) {
+                log.warn("exception", e);
+            } finally {
+                if (!signals.compareAndSet(currentSignals, 0)) {
+                    // Someone signaled us while we were stealing, reschedule the signal to ourself
+                    execute(SignalWork.INSTANCE);
+                }
+            }
+        }
+
+        /**
+         * Signal this worker, so it can attempt to stil any pools currently registered in the bitset that are holding
+         * the current set of pools that do have some pending borrowers.
+         */
+        void signal() {
+            if (signals.getAndIncrement() == 0) {
+                execute(SignalWork.INSTANCE);
+            }
+        }
+
+        /**
+         * Signal the first available signalable pool which index is matching a specified predicate.
+         * @param filter the predicate used to select another worker
+         */
+        private void signalFirst(IntPredicate filter) {
+            workStealingPool.signalablePools.accept(index -> {
+                if (filter.test(index)) {
+                    workStealingPool.workers[index].signal();
+                    // stop iterating on next pending worker
+                    return false;
+                }
+                // continue iterating on next pending worker
+                return true;
+            });
+        }
+
+        /**
+         * Signal another random signalable pool which index is matching a specified predicate.
+         * @param filter the predicate used to select another worker
+         */
+        private void signalAny(IntPredicate filter) {
+            workStealingPool.signalablePools.acceptRandom(rnd, tempWorkerIndexes, index -> {
+                if (filter.test(index)) {
+                    workStealingPool.workers[index].signal();
+                    // stop iterating on next pending worker
+                    return false;
+                }
+                // continue iterating on next pending worker
+                return true;
+            });
+        }
+
+        private void runTask(Task<T> task) {
+            try {
+                task.run(pool);
+            } catch (Throwable t) {
+                log.warn("Exception caught while running worker task", t);
+            }
+        }
+
+        /**
+         * Try to steal any pending acquisition tasks from other workers registered in the bitset of the pending tasks.
+         * @return true if the current  worker pool can acquire more resources, false if not
+         */
+        private boolean stealPendingTasks() {
+            Worker<T>[] workers = workStealingPool.workers;
+            LongAdder stealCount = workStealingPool.stealCount;
+
+            workStealingPool.pendingTaskPools.acceptRandom(rnd, tempWorkerIndexes, index -> {
+                Task<T> work;
+                Worker<T> workerToSteal;
+                boolean canAcquire;
+
+                if (index == workerIndex) {
+                    // continue iterating on next random pool index
+                    return true;
+                }
+
+                workerToSteal = workers[index];
+
+                while ((canAcquire = pool.hasAvailableResources()) && (work = workerToSteal.queue.pollFirst()) != null) {
+                    stealCount.increment();
+                    runTask(work);
+                }
+                // if we can't acquire more resources, false is returned, meaning stop iterating over next random pending workers.
+                return canAcquire;
+            });
+
+            return pool.hasAvailableResources(); // true means we can still acquire more resources
+        }
+
+        /**
+         * Try to steal pending borrowers from other pools registered in the bitset of pending borrowers
+         * @return true if the current  worker pool can acquire more resources, false if not
+         */
+        private boolean stealPendingBorrowers() {
+            Worker<T>[] workers = workStealingPool.workers;
+            LongAdder stealCount = workStealingPool.stealCount;
+
+            workStealingPool.pendingBorrowerPools.acceptRandom(rnd, tempWorkerIndexes, index -> {
+                Worker<T> workerToSteal;
+                boolean canAcquire;
+
+                if (index == workerIndex) {
+                    return true;
+                }
+                workerToSteal = workers[index];
+                while ((canAcquire = pool.hasAvailableResources()) && pool.transferBorrowersFrom(workerToSteal.pool)) {
+                    stealCount.add(1);
+                }
+                return canAcquire;
+            });
+
+            return pool.hasAvailableResources();
+        }
+
+        /**
+         * Sub pools implementation are assumed to call this method when either one idle resources becomes available
+         * or when some more resources can be allocated. The method will then signal the associated worker, so it can
+         * attempt to steal other pools that currently do have some pending borrowers or some pending acquisition tasks.
+         */
+        @Override
+        public void resourceAvailable() {
+            signal();
+        }
+    }
+
+    /**
+     * Efficiently manages a set of enabled bits using an AtomicIntegerArray.
+     */
+    static final class AtomicBitSet {
+        private final AtomicIntegerArray bits;
+
+        interface BitsVisitor {
+            boolean accept(int index);
+        }
+
+        /**
+         * Constructs an AtomicBitSet with the specified number of bits.
+         *
+         * @param bits The number of bits to accommodate.
+         */
+        AtomicBitSet(int bits) {
+            // determines the required length of the AtomicIntegerArray to accommodate the specified number of bits.
+            // Adds 31 to the bits for division rounding purposes, making sure it's rounded up to the nearest multiple of 32,
+            // and then divide it 32.
+            int arrayLength = (bits + 31) >>> 5; // unsigned / 32
+            this.bits = new AtomicIntegerArray(arrayLength);
+        }
+
+        /**
+         * Clear all bits
+         */
+        void clear() {
+            int length = bits.length();
+            for (int i = 0; i < length; i++) {
+                bits.set(i, 0);
+            }
+        }
+
+        /**
+         * Sets the specified bit.
+         *
+         * @param n The index of the bit to set.
+         * @return the previous value
+         */
+         int set(int n) {
+            int mask = 1 << n;
+            int index = n >>> 5;
+            return bits.getAndAccumulate(index, mask, (oldValue, maskToAdd) -> oldValue | maskToAdd);
+        }
+
+        /**
+         * Unsets the specified bit if it was previously set.
+         *
+         * @param n The index of the bit to unset.
+         * @return true if the bit has been unset, false if not
+         */
+        boolean unsetIfSet(int n) {
+            int mask = 1 << n;
+            int index = n >>> 5;
+            int oldValue = bits.get(index);
+            boolean wasSet = (oldValue & mask) != 0;
+
+            if (wasSet) {
+                return bits.compareAndSet(index, oldValue, oldValue & ~mask);
+            }
+            return false;
+        }
+
+        /**
+         * Sets the specified bit if it wasn't previously set.
+         *
+         * @param n The index of the bit to set if not already set.
+         * @return true if the bit has been set, false if not
+         */
+        boolean setIfNotSet(int n) {
+            int mask = 1 << n;
+            int index = n >>> 5;
+            int oldValue = bits.get(index);
+            boolean wasSet = (oldValue & mask) != 0;
+
+            if (!wasSet) {
+                return bits.compareAndSet(index, oldValue, oldValue | mask);
+            }
+            return false;
+        }
+
+        /**
+         * Unsets the specified bit.
+         *
+         * @param n The index of the bit to unset.
+         */
+        void unset(int n) {
+            int mask = ~(1 << n);
+            int index = n >>> 5;
+            bits.getAndAccumulate(index, mask, (oldValue, maskToRemove) -> oldValue & maskToRemove);
+        }
+
+        /**
+         * Checks if the specified bit is enabled.
+         *
+         * @param n The index of the bit to check.
+         * @return True if the bit is set, false otherwise.
+         */
+         boolean contains(int n) {
+            int bit = 1 << n;
+            int idx = n >>> 5;
+            int num = bits.get(idx);
+            return (num & bit) != 0;
+        }
+
+        /**
+         * Retrieves a random enabled bit index.
+         *
+         * @param rnd The ThreadLocalRandom object to generate randomness.
+         * @return A randomly chosen enabled bit index, or -1 if no bits are set.
+         */
+        public int getRandom(ThreadLocalRandom rnd) {
+            int length = bits.length();
+            int value = 0;
+            int randomIdx = 0;
+
+            if (length > 1) {
+                randomIdx = rnd.nextInt(length);
+                for (int i = 0; i < length; i ++) {
+                    if (randomIdx >= length) {
+                        randomIdx = 0;
+                    }
+                    value = bits.get(randomIdx);
+                    if (value != 0) {
+                        break;
+                    }
+                }
+            } else {
+                value = bits.get(0);
+            }
+
+            if (value == 0) {
+                return -1; // No bits are set to 1
+            }
+
+            int iterations = rnd.nextInt(1, Integer.bitCount(value) + 1);
+            int result = -1;
+            for (int i = 0; i < iterations && value != 0; i ++) {
+                int rightmostSetBit = value & -value; // Extract the rightmost set bit
+                int bitIndex = (randomIdx << 5) + Integer.numberOfTrailingZeros(rightmostSetBit); // Calculate bit index
+                result = bitIndex;
+                value &= (value - 1); // Clear the rightmost set bit
+            }
+
+            return result;
+        }
+
+        /**
+         * Retrieves all enabled bit indexes into the provided array.
+         * Take care, the provided array length is assumed to match the max number of enabled bits.
+         *
+         * @param result The array to store the enabled bit indexes.
+         * @return The count of enabled bits stored in the result array.
+         */
+        int getBits(int[] result) {
+            int count = 0;
+            for (int i = 0; i < bits.length(); i++) {
+                int value = bits.get(i);
+
+                while (value != 0) {
+                    int rightmostSetBit = value & -value; // Extract the rightmost set bit
+                    int bitIndex = (i << 5) + Integer.numberOfTrailingZeros(rightmostSetBit); // Calculate bit index
+                    result[count++] = bitIndex;
+                    if (count == result.length) {
+                        return count;
+                    }
+                    value &= (value - 1); // Clear the rightmost set bit
+                }
+            }
+            return count;
+        }
+
+        /**
+         * Retrieves random enabled bit indexes into the provided array.
+         * Take care, the provided array length is assumed to match the max number of enabled bits.
+         *
+         * @param result The array to store randomly chosen enabled bit indexes.
+         * @param rnd    The ThreadLocalRandom object to generate randomness.
+         * @return The count of enabled bits stored in the result array.
+         */
+         int getRandomBits(int[] result, ThreadLocalRandom rnd) {
+            int count = getBits(result);
+            // Fisher-Yates shuffle
+            for (int i = count - 1; i > 0; i--) {
+                int index = rnd.nextInt(i + 1);
+                int temp = result[index];
+                result[index] = result[i];
+                result[i] = temp;
+            }
+            return count;
+        }
+
+        /**
+         * Accepts a visitor for each enabled bit index.
+         *
+         * @param visitor The BitsVisitor implementing logic for accepted bit indexes. The iteration of enabled bits
+         *                stops when the visitor returns false, else it continues until no more enabled bits are available
+         */
+        int accept(BitsVisitor visitor) {
+            int visited = 0;
+            for (int i = 0; i < bits.length(); i++) {
+                int value = bits.get(i);
+
+                while (value != 0) {
+                    visited ++;
+                    int rightmostSetBit = value & -value; // Extract the rightmost set bit
+                    int bitIndex = (i << 5) + Integer.numberOfTrailingZeros(rightmostSetBit); // Calculate bit index
+                    if (!visitor.accept(bitIndex)) {
+                        return visited;
+                    }
+                    value &= (value - 1); // Clear the rightmost set bit
+                }
+            }
+            return visited;
+        }
+
+        /**
+         * Accepts a visitor for randomly chosen enabled bit indexes.
+         *
+         * @param random  The ThreadLocalRandom object to generate randomness.
+         * @param indexes The array containing randomly chosen bit indexes.
+         * @param visitor The BitsVisitor implementing logic for accepted bit indexes. The iteration of enabled bits
+         *                stops when the visitor returns false, else it continues until no more enabled bits are available
+         */
+        void acceptRandom(ThreadLocalRandom random, int[] indexes, BitsVisitor visitor) {
+            int size = getRandomBits(indexes, random);
+            if (size == 0) {
+                return;
+            }
+            for (int i = 0; i < size; i++) {
+                if (!visitor.accept(indexes[i])) {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/reactor-pool/src/test/java/reactor/pool/decorators/WorkStealingPoolBitSetTest.java
+++ b/reactor-pool/src/test/java/reactor/pool/decorators/WorkStealingPoolBitSetTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2024 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool.decorators;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import reactor.pool.decorators.WorkStealingPool.AtomicBitSet;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.anyOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WorkStealingPoolBitSetTest {
+
+    private static final int MAX_BITS = 64;
+    private static final int MAX_THREADS = 10;
+    private static final int REPEAT_COUNT = 1000;
+
+    @Test
+    void testSetAndGet() {
+        AtomicBitSet bitSet = new AtomicBitSet(MAX_BITS);
+        for (int i = 0; i < MAX_BITS; i ++) {
+            bitSet.clear();
+            bitSet.set(i);
+            assertTrue(bitSet.contains(i));
+        }
+    }
+
+    @Test
+    void testContains() {
+        AtomicBitSet bitSet = new AtomicBitSet(MAX_BITS);
+        int[] result = new int[MAX_BITS];
+
+        for (int i = 0; i < MAX_BITS; i ++) {
+            assertFalse(bitSet.contains(i));
+            bitSet.set(i);
+            assertTrue(bitSet.contains(i));
+            int count = bitSet.getBits(result);
+            assertEquals(i+1, count);
+            for (int j = 0; j < count; j ++) {
+                assertTrue(bitSet.contains(result[j]));
+            }
+        }
+    }
+
+    @Test
+    void testRandomBitOperations() {
+        int maxBits=100;
+        AtomicBitSet bitSet = new AtomicBitSet(maxBits);
+
+        for (int i = 0; i < maxBits; i += 2) {
+            bitSet.set(i);
+        }
+
+        int[] result = new int[maxBits];
+        int count = bitSet.getRandomBits(result, ThreadLocalRandom.current());
+
+        assertThat(count, is(50));
+
+        for (int value : result) {
+            assertThat(value % 2, is(0));
+            assertThat(bitSet.contains(value), is(true));
+        }
+
+        int randomIndex = bitSet.getRandom(ThreadLocalRandom.current());
+        assertThat(randomIndex, allOf(greaterThanOrEqualTo(0), lessThan(100), is(new EvenMatcher())));
+    }
+
+    @Test
+    void testVisitor() {
+        AtomicBitSet bitSet = new AtomicBitSet(MAX_BITS);
+
+        bitSet.set(3);
+        bitSet.set(8);
+        bitSet.set(15);
+
+        int[] result = new int[MAX_BITS];
+        bitSet.accept(index -> {
+            result[index] = index;
+            return true;
+        });
+
+        assertThat(result[3], is(3));
+        assertThat(result[8], is(8));
+        assertThat(result[15], is(15));
+
+        int[] visitedIndexes = new int[MAX_BITS];
+        int[] tmp = new int[MAX_BITS];
+        bitSet.acceptRandom(ThreadLocalRandom.current(), tmp, index -> {
+            visitedIndexes[index] = index;
+            return true;
+        });
+
+        assertThat(visitedIndexes[3], anyOf(is(3), is(8), is(15)));
+        assertThat(visitedIndexes[8], anyOf(is(3), is(8), is(15)));
+        assertThat(visitedIndexes[15], anyOf(is(3), is(8), is(15)));
+        for (int i = 0; i < MAX_BITS; i++) {
+            if (i != 3 && i != 8 && i != 15) {
+                assertThat(visitedIndexes[i], is(0));
+            }
+        }
+    }
+
+    @RepeatedTest(100)
+    void testConcurrentAccess() throws InterruptedException {
+        AtomicBitSet bitSet = new AtomicBitSet(MAX_BITS);
+        AtomicInteger counter = new AtomicInteger(0);
+        CountDownLatch latch = new CountDownLatch(MAX_THREADS * REPEAT_COUNT);
+        Thread[] threads = new Thread[MAX_THREADS];
+
+        for (int i = 0; i < MAX_THREADS; i++) {
+            (threads[i] = new Thread(() -> {
+                for (int j = 0; j < REPEAT_COUNT; j++) {
+                    int randomIndex = ThreadLocalRandom.current().nextInt(MAX_BITS);
+                    if (!bitSet.contains(randomIndex)) {
+                        if (bitSet.setIfNotSet(randomIndex)) {
+                            counter.incrementAndGet();
+                        }
+                    }
+                    latch.countDown();
+                }
+            })).start();
+        }
+
+        for (int i = 0; i < MAX_THREADS; i ++) {
+            threads[i].join();
+        }
+
+        latch.await();
+
+        // Ensure that all set operations were successful
+        assertEquals(counter.get(), bitSet.getBits(new int[MAX_BITS]));
+    }
+
+    static class EvenMatcher extends BaseMatcher<Integer> {
+        @Override
+        public boolean matches(Object item) {
+            if (!(item instanceof Integer)) {
+                return false;
+            }
+            return ((Integer) item) % 2 == 0;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("an even number");
+        }
+    }
+}

--- a/reactor-pool/src/test/java/reactor/pool/decorators/WorkStealingPoolTest.java
+++ b/reactor-pool/src/test/java/reactor/pool/decorators/WorkStealingPoolTest.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2024 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool.decorators;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.pool.*;
+import reactor.scheduler.clock.SchedulerClock;
+import reactor.test.StepVerifier;
+import reactor.test.scheduler.VirtualTimeScheduler;
+import reactor.test.util.RaceTestUtils;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+import reactor.util.function.Tuples;
+
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.awaitility.Awaitility.await;
+
+import reactor.core.scheduler.Schedulers;
+import reactor.pool.InstrumentedPool;
+
+class WorkStealingPoolTest {
+    final static Logger log = Loggers.getLogger(WorkStealingPoolTest.class);
+    static final int LOOPS = 100000;
+    static final int POOLS = 10;
+    static final int POOL_SIZE = 1000;
+    PoolScheduler<PiCalculator> pool;
+    List<ExecutorService> execs;
+
+    static final class PiCalculator {
+        public double calculatePi(int terms) {
+            double pi = 0.0;
+            for (int i = 0; i < terms; i++) {
+                double term = 1.0 / (2 * i + 1);
+                if (i % 2 == 0) {
+                    pi += term;
+                } else {
+                    pi -= term;
+                }
+            }
+            return pi * 4.0;
+        }
+    }
+
+    @BeforeEach
+    void init() {
+        execs = IntStream.range(0, POOLS).mapToObj(i -> Executors.newSingleThreadExecutor()).collect(Collectors.toList());
+        Iterator<ExecutorService> execsIter = execs.iterator();
+        Mono<PiCalculator> allocator = Mono.defer(() -> Mono.just(new PiCalculator()));
+        pool = InstrumentedPoolDecorators.concurrentPools(POOLS, allocator, poolBuilder ->
+                Tuples.of(poolBuilder.sizeBetween(1, POOL_SIZE / POOLS).buildPool(), execsIter.next()));
+    }
+
+    @AfterEach
+    void destroy() {
+        pool.disposeLater().block(Duration.ofSeconds(3));
+        execs.forEach(exec -> {
+            try {
+                exec.shutdown();
+                if (!exec.awaitTermination(10, TimeUnit.SECONDS)) {
+                    throw new RuntimeException("Could not terminate executor timely.");
+                }
+            } catch (InterruptedException e) {
+            }
+        });
+    }
+
+    @Test
+    @RepeatedTest(100)
+    void smokeTest() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        pool.withPoolable(piCalculator -> Mono.just(piCalculator.calculatePi(3000)))
+                .subscribe(pi -> latch.countDown());
+
+        if (!latch.await(10, TimeUnit.SECONDS)) {
+            fail("could not acquire resource timely");
+        }
+
+        assertThat(pool.metrics().allocatedSize()).isGreaterThan(0);
+
+        await().atMost(3, TimeUnit.SECONDS).with().pollInterval(10, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> assertThat(pool.metrics().idleSize())
+                        .as("idle size should be equal to 1")
+                        .isGreaterThan(0));
+        System.out.println("Workers: " + pool.toString());
+    }
+
+    @Test
+    @RepeatedTest(100)
+    void timeoutTest() throws InterruptedException {
+        // allocate all resources
+        List<PooledRef<PiCalculator>> refs = IntStream.range(0, POOL_SIZE)
+                .mapToObj(i -> pool.acquire(Duration.ofSeconds(4)).block())
+                .collect(Collectors.toList());
+
+        //error, we should get a timed out
+        pool.acquire(Duration.ofMillis(1))
+                .as(StepVerifier::create)
+                .expectError(PoolAcquireTimeoutException.class)
+                .verify(Duration.ofSeconds(3));
+
+        refs.forEach(ref -> ref.release().block(Duration.ofSeconds(1)));
+        System.out.println("Workers: " + pool.toString());
+    }
+
+    @Test
+    @RepeatedTest(100)
+    void acquireAllTest() throws InterruptedException {
+        List<PooledRef<PiCalculator>> refs = IntStream.range(0, POOL_SIZE)
+                .mapToObj(i -> pool.acquire(Duration.ofSeconds(4)).block())
+                .collect(Collectors.toList());
+        await().atMost(3, TimeUnit.SECONDS).with().pollInterval(10, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> assertThat(pool.metrics().idleSize())
+                        .as("idle size should be equal to 0")
+                        .isEqualTo(0));
+        refs.forEach(r -> r.release().block(Duration.ofSeconds(1)));
+    }
+
+    @Test
+    @RepeatedTest(100)
+    void testReleaseAfterQuiescenceFullPools() throws InterruptedException {
+        List<PooledRef<PiCalculator>> refs = IntStream.range(0, POOL_SIZE)
+                .mapToObj(i -> pool.acquire(Duration.ofSeconds(1)).block())
+                .collect(Collectors.toList());
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<PooledRef<PiCalculator>> ref = new AtomicReference<>();
+        pool.acquire().subscribe(r -> {
+            ref.set(r);
+            latch.countDown();
+        });
+
+        AtomicBoolean removed = new AtomicBoolean();
+
+        refs.remove(0)
+                .release()
+                .doOnSuccess(__ -> {
+                    removed.set(true);
+                })
+                .block(Duration.ofSeconds(1));
+
+        assertThat(latch.await(1, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(ref.get()).isNotNull();
+        assertThat(pool.metrics().allocatedSize()).isEqualTo(POOL_SIZE);
+        ref.get().release().block(Duration.ofSeconds(1));
+        refs.forEach(r -> r.release().block(Duration.ofSeconds(1)));
+        await().atMost(3, TimeUnit.SECONDS).with().pollInterval(10, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> assertThat(pool.metrics().idleSize())
+                        .as("idle size should be equal to 1")
+                        .isGreaterThan(0));
+    }
+
+    @Test
+    @RepeatedTest(10)
+    void testPerformance() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(LOOPS);
+        Flux.range(0, LOOPS)
+                .flatMap(i -> pool.withPoolable(piCalculator -> Mono.just(piCalculator.calculatePi(3000))))
+                .doOnNext(pi -> latch.countDown())
+                .subscribe();
+
+        assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
+        assertThat(pool.stealCount() > 0).isTrue();
+    }
+
+    @Test
+    @Tag("loops")
+    void acquireReleaseRaceWithMinSize_loop() {
+        final Scheduler racer = Schedulers.fromExecutorService(Executors.newFixedThreadPool(2));
+        AtomicInteger newCount = new AtomicInteger();
+        try {
+            Mono<TestUtils.PoolableTest> allocator = Mono.fromCallable(() -> new TestUtils.PoolableTest(newCount.getAndIncrement()));
+            Iterator<ExecutorService> execsIter = execs.iterator();
+
+            InstrumentedPool<TestUtils.PoolableTest> pool = InstrumentedPoolDecorators.concurrentPools(2, allocator, poolBuilder ->
+                    Tuples.of(poolBuilder.sizeBetween(2, 5)
+                            .buildPool(), execsIter.next()));
+
+            for (int i = 0; i < 100; i++) {
+                RaceTestUtils.race(racer,
+                        () -> pool.acquire().block().release().block(),
+                        () -> pool.acquire().block().release().block());
+            }
+            //we expect that only 3 element was created
+            assertThat(newCount).as("elements created in total").hasValue(4);
+        }
+        finally {
+            pool.disposeLater().block(Duration.ofSeconds(3));
+            racer.dispose();
+        }
+    }
+
+    @Test
+    @RepeatedTest(10)
+    @Disabled
+    void testAvoidReallocationAfterEviction() throws InterruptedException {
+        VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+        AtomicInteger allocCounter = new AtomicInteger();
+        Mono<MyResource> allocator = Mono.defer(() -> Mono.just(new MyResource(vts, allocCounter.incrementAndGet())));
+
+        Iterator<ExecutorService> execsIter = execs.iterator();
+        InstrumentedPool<MyResource> pool = InstrumentedPoolDecorators.concurrentPools(2, allocator, poolBuilder ->
+                Tuples.of(poolBuilder.sizeBetween(0, 1)
+                        .evictionPredicate((poolable, metadata) -> vts.now(TimeUnit.MILLISECONDS) - poolable.releaseTimestamp > 4000)
+				        .releaseHandler(pt -> Mono.fromRunnable(pt::release))
+                        .buildPool(), execsIter.next()));
+
+        PooledRef<MyResource> ref1 = pool.acquire().block();
+        PooledRef<MyResource> ref2 = pool.acquire().block();
+
+        ref1.release().block();
+        assertThatCode(() -> vts.advanceTimeBy(Duration.ofSeconds(10))).doesNotThrowAnyException();
+        ref2.release().block();
+        ref2 = pool.acquire().block();
+
+        assertThat(ref2.poolable().id).as("allocations").isEqualTo(2);
+        assertThat(allocCounter).as("allocations").hasValue(2);
+
+        ref1 = pool.acquire().block();
+        assertThat(ref1.poolable().id).as("allocations").isEqualTo(3);
+        assertThat(allocCounter).as("allocations").hasValue(3);
+        assertThat(pool.metrics().allocatedSize()).as("metrics().allocatedSize()").isEqualTo(2);
+
+        ref1.release().block();
+        ref2.release().block();
+        pool.disposeLater().block(Duration.ofSeconds(3));
+    }
+
+    @Test
+    @RepeatedTest(100)
+    @Disabled
+    void testAvoidReallocationAfterEvictionMany() throws InterruptedException {
+        VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+
+        AtomicInteger allocCounter = new AtomicInteger();
+        AtomicInteger destroyCounter = new AtomicInteger();
+
+        Iterator<ExecutorService> execsIter = execs.iterator();
+        Mono<Integer> allocator = Mono.fromCallable(allocCounter::incrementAndGet);
+
+        InstrumentedPool<Integer> pool = InstrumentedPoolDecorators.concurrentPools(POOLS, allocator, poolBuilder ->
+                Tuples.of(poolBuilder.sizeBetween(0, POOL_SIZE / POOLS)
+                        .evictionPredicate((poolable, metadata) -> metadata.idleTime() >= 4000)
+                        .evictInBackground(Duration.ofSeconds(5), vts)
+                        .destroyHandler(i -> Mono.fromRunnable(destroyCounter::incrementAndGet))
+                        .clock(SchedulerClock.of(vts))
+                        .buildPool(), execsIter.next()));
+
+        List<PooledRef<Integer>> refs = IntStream.range(0, POOL_SIZE)
+                .mapToObj(i -> pool.acquire(Duration.ofSeconds(1)).block())
+                .collect(Collectors.toList());
+
+        assertThat(allocCounter).as("allocations").hasValue(POOL_SIZE);
+
+        for (int i = 0; i < POOL_SIZE-1; i ++) {
+            refs.remove(0).release().block();
+        }
+
+        assertThatCode(() -> vts.advanceTimeBy(Duration.ofSeconds(10))).doesNotThrowAnyException();
+
+        refs.remove(0).release().block();
+
+        PooledRef<Integer> ref = pool.acquire().block();
+        assertThat(allocCounter).as("allocations").hasValue(POOL_SIZE);
+        assertThat(ref.poolable()).as("allocations").isEqualTo(POOL_SIZE);
+        assertThat(pool.metrics().allocatedSize()).as("allocations").isEqualTo(1);
+        ref.release().block();
+        pool.disposeLater().block(Duration.ofSeconds(3));
+    }
+
+    @Test
+    @RepeatedTest(100)
+    @Disabled
+    void testAvoidReallocationAfterEvictionDaemon() throws InterruptedException {
+        VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+
+        AtomicInteger allocCounter = new AtomicInteger();
+        AtomicInteger destroyCounter = new AtomicInteger();
+
+        Iterator<ExecutorService> execsIter = execs.iterator();
+        Mono<Integer> allocator = Mono.fromCallable(allocCounter::incrementAndGet);
+
+        InstrumentedPool<Integer> pool = InstrumentedPoolDecorators.concurrentPools(2, allocator, poolBuilder ->
+                Tuples.of(poolBuilder.sizeBetween(0, 1)
+                        .evictionPredicate((poolable, metadata) -> metadata.idleTime() >= 4000)
+                        .evictInBackground(Duration.ofSeconds(5), vts)
+                        .destroyHandler(i -> Mono.fromRunnable(destroyCounter::incrementAndGet))
+                        .clock(SchedulerClock.of(vts))
+                        .buildPool(), execsIter.next()));
+
+        PooledRef<Integer> ref1 = pool.acquire().block();
+        PooledRef<Integer> ref2 = pool.acquire().block();
+
+        ref1.release().block();
+        assertThatCode(() -> vts.advanceTimeBy(Duration.ofSeconds(10))).doesNotThrowAnyException();
+        ref2.release().block();
+        ref2 = pool.acquire().block();
+        assertThat(ref2.poolable()).as("allocations").isEqualTo(2);
+        ref2.release().block();
+        assertThat(allocCounter).as("allocations").hasValue(2);
+        assertThat(pool.metrics().allocatedSize()).as("allocations").isEqualTo(1);
+        pool.disposeLater().block(Duration.ofSeconds(3));
+    }
+
+    static final class MyResource {
+        volatile long releaseTimestamp;
+        final int id;
+        final VirtualTimeScheduler vts;
+
+        MyResource(VirtualTimeScheduler vts, int id) {
+            this.vts = vts;
+            this.id = id;
+        }
+
+        void release() {
+            releaseTimestamp = vts.now(TimeUnit.MILLISECONDS);
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a new feature for the Reactor Pool, aimed at preventing resource starvation in highly concurrent scenarios. Currently, when multiple threads simultaneously acquire and release resources, the SimpleDequeuePool's `drainLoop` method can monopolize a CPU core, causing a bottleneck where other threads may remain less utilized.

There are of course existing ways to prevent one thread being executing the drainLoop method for a too long time, one can for instance use an `acquisition scheduler`, in order to offload borrowers delivery using a configured scheduler, at the cost of using extra threads. 

This PR experiments another way to offload the delivery of borrowers. Instead of using an acquisition scheduler, a concurrent `InstrumentedPoolDecorator` can be used. it allows to create a pool composed of multiple sub pools, each managing a portion of resources. Application Executors (i.e Netty Event Loops for example) can then be reused and  assigned to each sub pools, where acquisitions tasks will be scheduled. No extra threads will be created. This design enables concurrent distribution of resource acquisitions across these sub-pools, using a work-stealing approach where a busy sub-pool can be helped by another free sub-pool, which can steal acquisition tasks from the busy sub-pool.

For instance, in Reactor Netty, each Netty Event Loop thread will have its sub-pool with its assigned HTTP/2 connection resources.

The work is still in progress (even I'm not sure about the API), some issues remain and **this PR could be merged in a temporary branch**, in order to make it easier to continue the work on it. I don't have created a branch for the moment, to be confirmed by the Reactor team.

Attached to this PR a JMH project which compares the different approaches. The `WorkStealingPoolBenchmark`simulates a netty application which run hundreds of thousands of tasks running within an EventLoop Group. Each task will then acquire and release some resources. The benchmark needs this PR to be compiled and installed in local M2.

See attached 
[reactor-pool-jmh.tgz](https://github.com/reactor/reactor-pool/files/13902434/reactor-pool-jmh.tgz)


In the  WorkStealingPoolBenchmark class:

- benchWithSimplePool: this method simulates activities that are running within a Netty EventLoop group. So tasks are scheduled in Event Loops, each one is then acquiring/releasing a `PiCalculator` resources. When a  task has acquired a PICalculator, the PI number is computed, and the PiCalculator is then returned to the pool. When running this method, there will be actually one single running thread: it will be the one that is running the drainLoop method, which will spend it's life delivering "PiCalculator" resources to all borrowers from all event loop threads. Since no acquisition scheduler is used, the drainLoop is then consuming one core forever, and other tasks are just scheduling acquisition tasks to the pool. Check with Top, the process only consume 125% of total CPUs. The test runs in about 18 seconds on a Mac M1 with 10 cpus.

- benchWithAcquisitionSchedulerEventLoop: this benchmark tries to avoid the starvation problem by using an acquisition scheduler, where all borrowers are then delivered using the EventLoopGroup of the simulated application. This significantly improves performance (see below the results: about 10.78 secs).

- benchWithAcquisitionSchedulerFJP: this time, the common system ForkJoinPool is used to offload deliveries of borrowers. This improves even more performances, at the cost of using extra threads (in Reactor Netty, idealy, for example, we would like to avoid using extra threads, only the event loop threads ...): 5.11 sec.

- finally, the benchWithConcurrentPools method is doing a benchmark with this PR: a "concurrent" InstrumentedPool, composed of multiple sub pools, each one assigned to each Event Loop Executors: 2.75 sec.

The results are the following (tested with JDK 21):
(lesser score is better)

```
Benchmark                                                         Mode  Cnt  Score   Error  Units
WorkStealingPoolBenchmark.benchWithAcquisitionSchedulerEventLoop  avgt       1.222           s/op
WorkStealingPoolBenchmark.benchWithAcquisitionSchedulerFJP        avgt       1.239           s/op
WorkStealingPoolBenchmark.benchWithConcurrentPools                avgt       0.894           s/op
WorkStealingPoolBenchmark.benchWithSimplePool                     avgt       6.612           s/op
```

Remaining issues:

- The WorkStealingPool is not implementing any idle resource reuse LRU or MRU order configured via PoolBuilder.idleResourceReuseLruOrder or PoolBuilder.idleResourceReuseMruOrder. Only the sub-pools implement the configured idle resource reuse strategy. I actually wonder how this could be implemented globally on top of all sub pools.
- Metrics are implemented naively, by iterating over all sub pools. Common metrics with some long adders should be shared between all sub pools !
- The WorkStealingPool config() method is currently returning the config of the first sub-pool, this is questionable ... maybe a concurrent pool should be created using a PoolBuilder, so it can have its own config. Currently, the concurrent pool is created using `InstrumentedPoolDecorators.concurrentPools` factory method.
