### PR TITLE
Warmup throws IllegalArgumentException in case no permits are available

### DIFF
--- a/reactor-pool/src/main/java/reactor/pool/SimpleDequePool.java
+++ b/reactor-pool/src/main/java/reactor/pool/SimpleDequePool.java
@@ -230,6 +230,9 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 				recordInteractionTimestamp();
 				int initSize = poolConfig.allocationStrategy()
 				                         .getPermits(0);
+				if (initSize <= 0) {
+					return Mono.just(0);
+				}
 				@SuppressWarnings({ "unchecked", "rawtypes" }) //rawtypes added since javac actually complains
 				Mono<POOLABLE>[] allWarmups = new Mono[initSize];
 				for (int i = 0; i < initSize; i++) {


### PR DESCRIPTION
This fixes a regression that comes from #171, from 1.0.1 version: 

since the pool warmup method allows to be called at anytime, then if no more permits are available from the allocation strategy, the Flux.merge method is then called with a `mergeConcurrency`pameter that is set to `0`, causing the following exception:

```
maxConcurrency > 0 required but it was 0
java.lang.IllegalArgumentException: maxConcurrency > 0 required but it was 0
	at reactor.core.publisher.FluxFlatMap.<init>(FluxFlatMap.java:74)
	at reactor.core.publisher.Flux.merge(Flux.java:1406)
	at reactor.core.publisher.Flux.merge(Flux.java:1375)
```

Added a check in warmup to immediately return in case no permits are available.
Also added a test case.

Fixes #180