### PR TITLE
Format fix for PooMetrics interface inside AbstractPool.java

### DIFF
--- a/reactor-pool/src/main/java/reactor/pool/AbstractPool.java
+++ b/reactor-pool/src/main/java/reactor/pool/AbstractPool.java
@@ -46,8 +46,7 @@ import static reactor.pool.AbstractPool.AbstractPooledRef.STATE_INVALIDATED;
  * @author Simon Baslé
  * @author Violeta Georgieva
  */
-abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>,
-												 InstrumentedPool.PoolMetrics {
+abstract class AbstractPool<POOLABLE> implements InstrumentedPool<POOLABLE>, InstrumentedPool.PoolMetrics {
 
 	//A pool should be rare enough that having instance loggers should be ok
 	//This helps with testability of some methods that for now mainly log


### PR DESCRIPTION
Hello Team,

I observed a formatting issue where the interface "InstrumentedPool.PoolMetrics" was formatted  on a second line for the AbstractPool class.

As per my eyes, it seemed inconvenient and hence suggested a fix for the same.
Kindly let me know your thoughts on this formatting suggestion.