### PR TITLE
Remove `gradle/actions/setup-gradle` deprecated functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,9 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 8
-    - uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda
-      name: license header check
-      with:
-        arguments: spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
-    - uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda
-      name: gradle
-      with:
-        arguments: check javadoc
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70
+    - name: license header check
+      run: ./gradlew spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
+    - name: gradle
+      run: ./gradlew check javadoc


### PR DESCRIPTION
Using the action to execute Gradle via the `arguments` parameter is deprecated https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated