### PR TITLE
Cancel allocator after borrower is canceled.

### DIFF
--- a/reactor-pool/src/main/java/reactor/pool/SimpleDequePool.java
+++ b/reactor-pool/src/main/java/reactor/pool/SimpleDequePool.java
@@ -439,7 +439,9 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 
 						if (permits == 1) {
 							//subscribe to the primary, which will directly feed to the borrower
-							primary.subscribe(alreadyPropagated -> { }, alreadyPropagatedOrLogged -> drain(), this::drain);
+							Disposable disposable = primary.subscribe(alreadyPropagated -> {
+							}, alreadyPropagatedOrLogged -> drain(), this::drain);
+							borrower.onCancel(disposable);
 						}
 						else {
 							/*=============================================*

--- a/reactor-pool/src/test/java/reactor/pool/AcquireDefaultPoolTest.java
+++ b/reactor-pool/src/test/java/reactor/pool/AcquireDefaultPoolTest.java
@@ -171,8 +171,9 @@ class AcquireDefaultPoolTest {
 			try {
 
 				InstrumentedPool<PoolableTest> pool = poolableTestBuilder(0, 1,
-						Mono.defer(() -> Mono.delay(Duration.ofMillis(50)).thenReturn(new PoolableTest(newCount.incrementAndGet())))
-							.subscribeOn(scheduler),
+						Mono.defer(() -> Mono.delay(Duration.ofMillis(50))
+										.flatMap(__->Mono.fromSupplier(()->new PoolableTest(newCount.incrementAndGet()))))
+								.subscribeOn(scheduler),
 						pt -> releasedCount.incrementAndGet())
 .buildPool();
 
@@ -562,7 +563,8 @@ class AcquireDefaultPoolTest {
 			Scheduler scheduler = Schedulers.newParallel("poolable test allocator");
 
 			InstrumentedPool<PoolableTest> pool = poolableTestBuilder(0, 1,
-					Mono.defer(() -> Mono.delay(Duration.ofMillis(50)).thenReturn(new PoolableTest(newCount.incrementAndGet())))
+					Mono.defer(() -> Mono.delay(Duration.ofMillis(50))
+									.flatMap(__->Mono.fromSupplier(()->new PoolableTest(newCount.incrementAndGet()))))
 						.subscribeOn(scheduler),
 					pt -> releasedCount.incrementAndGet())
 .buildPool();


### PR DESCRIPTION
I recently raised an issue ([#3531](https://github.com/reactor/reactor-netty/issues/3531)) in reactor-netty related to this PR. I found that in reactor-pool, when a Borrower is canceled, the allocator is not canceled as well. It seems appropriate to cancel the allocator afterward.  Therefore, I’m attempting to submit this PR. If there are any problems, could you please provide some guidance?

Modification: 
Replace the unit test allocatedReleasedIfBorrowerCancelled with cancelAllocatorIfBorrowerCancelled.