### PR TITLE
Add background async health check for unhealthy pooled resources

### DIFF
--- a/reactor-pool/src/main/java/reactor/pool/DefaultPoolConfig.java
+++ b/reactor-pool/src/main/java/reactor/pool/DefaultPoolConfig.java
@@ -27,6 +27,7 @@ import org.reactivestreams.Publisher;
 import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * A default {@link PoolConfig} that can be extended to bear more configuration options
@@ -51,6 +52,11 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 	protected final boolean                                       isIdleLRU;
 	protected final Duration                                      maxLifeTime;
 	protected final double                                        maxLifeTimeVariance;
+	protected final BiFunction<POOLABLE, PooledRefMetadata, ? extends Publisher<Boolean>> healthCheck;
+	protected final Duration                                      healthCheckInBackgroundInterval;
+	protected final Scheduler                                     healthCheckInBackgroundScheduler;
+	protected final Duration                                      healthCheckTimeout;
+	protected final int                                           healthCheckParallelism;
 
 	public DefaultPoolConfig(Mono<POOLABLE> allocator,
 			AllocationStrategy allocationStrategy,
@@ -87,6 +93,35 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 			boolean isIdleLRU,
 			Duration maxLifeTime,
 			double maxLifeTimeVariance) {
+		this(allocator, allocationStrategy, maxPending, pendingAcquireTimer,
+				releaseHandler, destroyHandler, evictionPredicate,
+				evictInBackgroundInterval, evictInBackgroundScheduler,
+				acquisitionScheduler, metricsRecorder, clock, isIdleLRU,
+				maxLifeTime, maxLifeTimeVariance,
+				(poolable, meta) -> Mono.just(true), Duration.ZERO,
+				Schedulers.immediate(), Duration.ZERO, 1);
+	}
+
+	public DefaultPoolConfig(Mono<POOLABLE> allocator,
+			AllocationStrategy allocationStrategy,
+			int maxPending,
+			BiFunction<Runnable, Duration, Disposable> pendingAcquireTimer,
+			Function<POOLABLE, ? extends Publisher<Void>> releaseHandler,
+			Function<POOLABLE, ? extends Publisher<Void>> destroyHandler,
+			BiPredicate<POOLABLE, PooledRefMetadata> evictionPredicate,
+			Duration evictInBackgroundInterval,
+			Scheduler evictInBackgroundScheduler,
+			Scheduler acquisitionScheduler,
+			PoolMetricsRecorder metricsRecorder,
+			Clock clock,
+			boolean isIdleLRU,
+			Duration maxLifeTime,
+			double maxLifeTimeVariance,
+			BiFunction<POOLABLE, PooledRefMetadata, ? extends Publisher<Boolean>> healthCheck,
+			Duration healthCheckInBackgroundInterval,
+			Scheduler healthCheckInBackgroundScheduler,
+			Duration healthCheckTimeout,
+			int healthCheckParallelism) {
 		this.pendingAcquireTimer = pendingAcquireTimer;
 		this.allocator = allocator;
 		this.allocationStrategy = allocationStrategy;
@@ -102,6 +137,11 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 		this.isIdleLRU = isIdleLRU;
 		this.maxLifeTime = maxLifeTime;
 		this.maxLifeTimeVariance = maxLifeTimeVariance;
+		this.healthCheck = healthCheck;
+		this.healthCheckInBackgroundInterval = healthCheckInBackgroundInterval;
+		this.healthCheckInBackgroundScheduler = healthCheckInBackgroundScheduler;
+		this.healthCheckTimeout = healthCheckTimeout;
+		this.healthCheckParallelism = healthCheckParallelism;
 	}
 
 	/**
@@ -128,6 +168,11 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 			this.isIdleLRU = toCopyDpc.isIdleLRU;
 			this.maxLifeTime = toCopyDpc.maxLifeTime;
 			this.maxLifeTimeVariance = toCopyDpc.maxLifeTimeVariance;
+			this.healthCheck = toCopyDpc.healthCheck;
+			this.healthCheckInBackgroundInterval = toCopyDpc.healthCheckInBackgroundInterval;
+			this.healthCheckInBackgroundScheduler = toCopyDpc.healthCheckInBackgroundScheduler;
+			this.healthCheckTimeout = toCopyDpc.healthCheckTimeout;
+			this.healthCheckParallelism = toCopyDpc.healthCheckParallelism;
 		}
 		else {
 			this.allocator = toCopy.allocator();
@@ -145,6 +190,11 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 			this.isIdleLRU = toCopy.reuseIdleResourcesInLruOrder();
 			this.maxLifeTime = toCopy.maxLifeTime();
 			this.maxLifeTimeVariance = toCopy.maxLifeTimeVariance();
+			this.healthCheck = toCopy.healthCheck();
+			this.healthCheckInBackgroundInterval = toCopy.healthCheckInBackgroundInterval();
+			this.healthCheckInBackgroundScheduler = toCopy.healthCheckInBackgroundScheduler();
+			this.healthCheckTimeout = toCopy.healthCheckTimeout();
+			this.healthCheckParallelism = toCopy.healthCheckParallelism();
 		}
 	}
 
@@ -221,5 +271,30 @@ public class DefaultPoolConfig<POOLABLE> implements PoolConfig<POOLABLE> {
 	@Override
 	public double maxLifeTimeVariance() {
 		return this.maxLifeTimeVariance;
+	}
+
+	@Override
+	public BiFunction<POOLABLE, PooledRefMetadata, ? extends Publisher<Boolean>> healthCheck() {
+		return this.healthCheck;
+	}
+
+	@Override
+	public Duration healthCheckInBackgroundInterval() {
+		return this.healthCheckInBackgroundInterval;
+	}
+
+	@Override
+	public Scheduler healthCheckInBackgroundScheduler() {
+		return this.healthCheckInBackgroundScheduler;
+	}
+
+	@Override
+	public Duration healthCheckTimeout() {
+		return this.healthCheckTimeout;
+	}
+
+	@Override
+	public int healthCheckParallelism() {
+		return this.healthCheckParallelism;
 	}
 }

--- a/reactor-pool/src/main/java/reactor/pool/PoolBuilder.java
+++ b/reactor-pool/src/main/java/reactor/pool/PoolBuilder.java
@@ -81,6 +81,11 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
 	BiFunction<Runnable, Duration, Disposable> pendingAcquireTimer     = DEFAULT_PENDING_ACQUIRE_TIMER;
 	Duration                               maxLifeTime                 = Duration.ZERO;
 	double                                 maxLifeTimeVariance         = 0d;
+	BiFunction<T, PooledRefMetadata, ? extends Publisher<Boolean>> healthCheck = alwaysHealthy();
+	Duration                               healthCheckInBackgroundInterval  = Duration.ZERO;
+	Scheduler                              healthCheckInBackgroundScheduler = Schedulers.immediate();
+	Duration                               healthCheckTimeout          = Duration.ZERO;
+	int                                    healthCheckParallelism      = 1;
 
 	PoolBuilder(Mono<T> allocator, Function<PoolConfig<T>, CONF> configModifier) {
 		this.allocator = allocator;
@@ -105,6 +110,11 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
 		this.pendingAcquireTimer = source.pendingAcquireTimer;
 		this.maxLifeTime = source.maxLifeTime;
 		this.maxLifeTimeVariance = source.maxLifeTimeVariance;
+		this.healthCheck = source.healthCheck;
+		this.healthCheckInBackgroundInterval = source.healthCheckInBackgroundInterval;
+		this.healthCheckInBackgroundScheduler = source.healthCheckInBackgroundScheduler;
+		this.healthCheckTimeout = source.healthCheckTimeout;
+		this.healthCheckParallelism = source.healthCheckParallelism;
 	}
 
 	/**
@@ -322,6 +332,127 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
 					"maxLifeTimeVariance must be between 0 and 100, was " + variancePercent);
 		}
 		this.maxLifeTimeVariance = variancePercent;
+		return this;
+	}
+
+	/**
+	 * Provide an asynchronous health check {@link BiFunction} that a background reaping process can use to detect
+	 * idle resources that have become unhealthy (eg. a database connection silently dropped by the network or the
+	 * server) despite being within their configured idle/life time.
+	 * <p>
+	 * Unlike {@link #evictionPredicate(BiPredicate)}, which is synchronous, this returns a {@link Publisher},
+	 * allowing the check to perform a non-blocking remote call (eg. a validation query) without blocking the pool.
+	 * The resource under test is excluded from acquisition for the duration of the check: it cannot be handed out
+	 * concurrently while the returned {@link Publisher} is still active. A {@code true} emission (or the absence of
+	 * any emission) is interpreted as healthy; a {@code false} emission, an error, or exceeding
+	 * {@link #healthCheckTimeout(Duration)} is interpreted as unhealthy and destroys the resource, after which the
+	 * pool attempts to warm back up to its configured minimum size.
+	 * <p>
+	 * This only takes effect once background health checks are enabled via {@link #healthCheckInBackground(Duration)}.
+	 * Defaults to a health check that always considers the resource healthy (a no-op).
+	 *
+	 * @param healthCheck the asynchronous {@link BiFunction} that checks resource health
+	 * @return this {@link Pool} builder
+	 * @see #healthCheckInBackground(Duration)
+	 * @since 1.3.0
+	 */
+	public PoolBuilder<T, CONF> healthCheck(BiFunction<T, PooledRefMetadata, ? extends Publisher<Boolean>> healthCheck) {
+		this.healthCheck = Objects.requireNonNull(healthCheck, "healthCheck");
+		return this;
+	}
+
+	/**
+	 * Disable background health checks entirely.
+	 *
+	 * @return this {@link Pool} builder
+	 * @see #healthCheckInBackground(Duration)
+	 * @since 1.3.0
+	 */
+	public PoolBuilder<T, CONF> healthCheckInBackgroundDisabled() {
+		return healthCheckInBackground(Duration.ZERO);
+	}
+
+	/**
+	 * Enable background health checks so that the {@link #healthCheck(BiFunction) health check} is regularly applied
+	 * to idle elements in the pool, on {@link Schedulers#parallel()}.
+	 * <p>
+	 * Providing a {@code healthCheckInterval} of {@link Duration#ZERO zero} is similar to
+	 * {@link #healthCheckInBackgroundDisabled() disabling} background health checks.
+	 *
+	 * @param healthCheckInterval the {@link Duration} between two background health check sweeps
+	 * @return this {@link Pool} builder
+	 * @see #healthCheckInBackground(Duration, Scheduler)
+	 * @since 1.3.0
+	 */
+	public PoolBuilder<T, CONF> healthCheckInBackground(Duration healthCheckInterval) {
+		if (healthCheckInterval == Duration.ZERO) {
+			this.healthCheckInBackgroundInterval = Duration.ZERO;
+			this.healthCheckInBackgroundScheduler = Schedulers.immediate();
+			return this;
+		}
+		return this.healthCheckInBackground(healthCheckInterval, Schedulers.parallel());
+	}
+
+	/**
+	 * Enable background health checks so that the {@link #healthCheck(BiFunction) health check} is regularly applied
+	 * to idle elements in the pool, on the provided {@link Scheduler}.
+	 * <p>
+	 * Providing a {@code healthCheckInterval} of {@link Duration#ZERO zero} is similar to
+	 * {@link #healthCheckInBackgroundDisabled() disabling} background health checks.
+	 *
+	 * @param healthCheckInterval the {@link Duration} between two background health check sweeps
+	 * @param reaperTaskScheduler the {@link Scheduler} on which the background health check task is scheduled
+	 * @return this {@link Pool} builder
+	 * @see #healthCheckInBackground(Duration)
+	 * @since 1.3.0
+	 */
+	public PoolBuilder<T, CONF> healthCheckInBackground(Duration healthCheckInterval, Scheduler reaperTaskScheduler) {
+		Objects.requireNonNull(healthCheckInterval, "healthCheckInterval");
+		Objects.requireNonNull(reaperTaskScheduler, "reaperTaskScheduler");
+		if (healthCheckInterval.isNegative()) {
+			throw new IllegalArgumentException("healthCheckInterval must not be negative, was " + healthCheckInterval);
+		}
+		this.healthCheckInBackgroundInterval = healthCheckInterval;
+		this.healthCheckInBackgroundScheduler = reaperTaskScheduler;
+		return this;
+	}
+
+	/**
+	 * Set the maximum {@link Duration} a single {@link #healthCheck(BiFunction) health check} invocation is allowed
+	 * to take before the corresponding resource is considered unhealthy and destroyed.
+	 * <p>
+	 * Defaults to {@link Duration#ZERO}, meaning no timeout is applied.
+	 *
+	 * @param healthCheckTimeout the maximum {@link Duration} a health check is allowed to take, or {@link Duration#ZERO} to disable
+	 * @return this {@link Pool} builder
+	 * @see #healthCheck(BiFunction)
+	 * @since 1.3.0
+	 */
+	public PoolBuilder<T, CONF> healthCheckTimeout(Duration healthCheckTimeout) {
+		Objects.requireNonNull(healthCheckTimeout, "healthCheckTimeout");
+		if (healthCheckTimeout.isNegative()) {
+			throw new IllegalArgumentException("healthCheckTimeout must not be negative, was " + healthCheckTimeout);
+		}
+		this.healthCheckTimeout = healthCheckTimeout;
+		return this;
+	}
+
+	/**
+	 * Set the maximum number of idle resources that can be concurrently undergoing a background
+	 * {@link #healthCheck(BiFunction) health check} at any given time.
+	 * <p>
+	 * Defaults to {@literal 1}.
+	 *
+	 * @param healthCheckParallelism the maximum concurrency of background health checks, must be positive
+	 * @return this {@link Pool} builder
+	 * @see #healthCheck(BiFunction)
+	 * @since 1.3.0
+	 */
+	public PoolBuilder<T, CONF> healthCheckParallelism(int healthCheckParallelism) {
+		if (healthCheckParallelism < 1) {
+			throw new IllegalArgumentException("healthCheckParallelism must be positive, was " + healthCheckParallelism);
+		}
+		this.healthCheckParallelism = healthCheckParallelism;
 		return this;
 	}
 
@@ -572,7 +703,12 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
 				clock,
 				idleLruOrder,
 				maxLifeTime,
-				maxLifeTimeVariance);
+				maxLifeTimeVariance,
+				healthCheck,
+				healthCheckInBackgroundInterval,
+				healthCheckInBackgroundScheduler,
+				healthCheckTimeout,
+				healthCheckParallelism);
 
 		return this.configModifier.apply(baseConfig);
 	}
@@ -591,6 +727,12 @@ public class PoolBuilder<T, CONF extends PoolConfig<T>> {
 		return (poolable, meta) -> meta.idleTime() >= maxIdleTime.toMillis();
 	}
 
+	@SuppressWarnings("unchecked")
+	static <T> BiFunction<T, PooledRefMetadata, ? extends Publisher<Boolean>> alwaysHealthy() {
+		return (BiFunction<T, PooledRefMetadata, ? extends Publisher<Boolean>>) ALWAYS_HEALTHY;
+	}
+
+	static final BiFunction<?, ?, ? extends Publisher<Boolean>> ALWAYS_HEALTHY = (ignored1, ignored2) -> Mono.just(true);
 	static final Function<?, Mono<Void>> NOOP_HANDLER    = it -> Mono.empty();
 	static final BiPredicate<?, ?>       NEVER_PREDICATE = (ignored1, ignored2) -> false;
 	static final BiFunction<Runnable, Duration, Disposable> DEFAULT_PENDING_ACQUIRE_TIMER = (r, d) -> Schedulers.parallel().schedule(r, d.toNanos(), TimeUnit.NANOSECONDS);

--- a/reactor-pool/src/main/java/reactor/pool/PoolConfig.java
+++ b/reactor-pool/src/main/java/reactor/pool/PoolConfig.java
@@ -201,4 +201,71 @@ public interface PoolConfig<POOLABLE> {
 		return maxLifeTimeMs - ThreadLocalRandom.current().nextLong(varianceMs + 1);
 	}
 
+	/**
+	 * An asynchronous health check applied by a background reaping process to idle resources, in order to detect
+	 * resources that have become unhealthy (eg. a database connection that was silently dropped by the network or
+	 * the server) despite being within their configured idle/life time. Unlike {@link #evictionPredicate()}, which
+	 * is a synchronous {@link BiPredicate}, this returns a {@link Publisher} so that the check can perform a
+	 * non-blocking remote call (eg. a validation query) without blocking the pool's internals.
+	 * <p>
+	 * The resource is excluded from acquisition for the duration of the check. A {@code true} emission (or the
+	 * absence of any emission) is interpreted as healthy; a {@code false} emission, an error, or exceeding
+	 * {@link #healthCheckTimeout()} is interpreted as unhealthy and causes the resource to be destroyed.
+	 * <p>
+	 * Defaults to a health check that always considers the resource healthy (a no-op).
+	 *
+	 * @see #healthCheckInBackgroundInterval()
+	 * @since 1.3.0
+	 */
+	default BiFunction<POOLABLE, PooledRefMetadata, ? extends Publisher<Boolean>> healthCheck() {
+		return (poolable, meta) -> Mono.just(true); //TODO remove the default implementation in 2.0.0
+	}
+
+	/**
+	 * If the pool is configured to perform regular asynchronous health checks in the background, returns the
+	 * {@link Duration} representing the interval at which such checks are made. Otherwise returns
+	 * {@link Duration#ZERO} (the default, meaning disabled).
+	 *
+	 * @see #healthCheck()
+	 * @since 1.3.0
+	 */
+	default Duration healthCheckInBackgroundInterval() {
+		return Duration.ZERO; //TODO remove the default implementation in 2.0.0
+	}
+
+	/**
+	 * If the pool is configured to perform regular asynchronous health checks in the background, returns the
+	 * {@link Scheduler} on which the checks are scheduled. Otherwise returns {@link Schedulers#immediate()}
+	 * (the default).
+	 *
+	 * @see #healthCheck()
+	 * @since 1.3.0
+	 */
+	default Scheduler healthCheckInBackgroundScheduler() {
+		return Schedulers.immediate(); //TODO remove the default implementation in 2.0.0
+	}
+
+	/**
+	 * The maximum {@link Duration} a single {@link #healthCheck()} invocation is allowed to take before the
+	 * corresponding resource is considered unhealthy and destroyed. {@link Duration#ZERO} (the default) disables
+	 * the timeout, letting the {@link #healthCheck()} {@link Publisher} take as long as it needs.
+	 *
+	 * @see #healthCheck()
+	 * @since 1.3.0
+	 */
+	default Duration healthCheckTimeout() {
+		return Duration.ZERO; //TODO remove the default implementation in 2.0.0
+	}
+
+	/**
+	 * The maximum number of idle resources that can be concurrently undergoing a background {@link #healthCheck()}
+	 * at any given time. Defaults to {@literal 1}.
+	 *
+	 * @see #healthCheck()
+	 * @since 1.3.0
+	 */
+	default int healthCheckParallelism() {
+		return 1; //TODO remove the default implementation in 2.0.0
+	}
+
 }

--- a/reactor-pool/src/main/java/reactor/pool/SimpleDequePool.java
+++ b/reactor-pool/src/main/java/reactor/pool/SimpleDequePool.java
@@ -17,10 +17,15 @@
 package reactor.pool;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -99,6 +104,24 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 
 	@Nullable Disposable evictionTask;
 
+	@Nullable Disposable healthCheckTask;
+
+	/**
+	 * Refs popped out of {@link #idleResources} for an in-flight sweep whose check hasn't resolved yet, or
+	 * {@code null} if no sweep is in flight. {@link #reofferOrDestroy(QueuePooledRef, boolean)} removes a ref
+	 * from this set before reoffering or destroying it, so {@link #disposeLater()} can safely destroy whatever
+	 * remains (eg. a check stuck on a {@link Publisher} that never emits) without touching an already-finalized
+	 * ref that may since have been acquired by a borrower.
+	 */
+	volatile @Nullable Set<QueuePooledRef<POOLABLE>> healthCheckSweepCandidates;
+
+	volatile @Nullable Disposable healthCheckSweepSubscription;
+
+	volatile             int                                        healthCheckWip;
+	@SuppressWarnings("rawtypes")
+	private static final AtomicIntegerFieldUpdater<SimpleDequePool> HEALTH_CHECK_WIP =
+		AtomicIntegerFieldUpdater.newUpdater(SimpleDequePool.class, "healthCheckWip");
+
 	SimpleDequePool(PoolConfig<POOLABLE> poolConfig) {
 		super(poolConfig, Loggers.getLogger(SimpleDequePool.class));
 		this.idleResourceLeastRecentlyUsed = poolConfig.reuseIdleResourcesInLruOrder();
@@ -107,6 +130,7 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 		recordInteractionTimestamp();
 
 		scheduleEviction();
+		scheduleHealthCheck();
 	}
 
 	@Override
@@ -174,6 +198,165 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 		scheduleEviction();
 	}
 
+	void scheduleHealthCheck() {
+		if (isDisposed()) {
+			return;
+		}
+		if (!poolConfig.healthCheckInBackgroundInterval().isZero()) {
+			long nanosHealthCheckInterval = poolConfig.healthCheckInBackgroundInterval().toNanos();
+			this.healthCheckTask = poolConfig.healthCheckInBackgroundScheduler().schedule(this::healthCheckInBackground, nanosHealthCheckInterval, TimeUnit.NANOSECONDS);
+		}
+		else {
+			this.healthCheckTask = Disposables.disposed();
+		}
+	}
+
+	void healthCheckInBackground() {
+		@SuppressWarnings("unchecked")
+		Deque<QueuePooledRef<POOLABLE>> e = IDLE_RESOURCES.get(this);
+		if (e == null) {
+			//no need to schedule the task again, pool has been disposed
+			return;
+		}
+
+		//back off if there's pool activity or a sweep is already in progress, so as to not
+		//compete with drainLoop for idle resources nor pile up concurrent sweeps
+		if (pendingSize != 0 || !HEALTH_CHECK_WIP.compareAndSet(this, 0, 1)) {
+			scheduleHealthCheck();
+			return;
+		}
+
+		//select candidates under the same WIP guard evictInBackground/drainLoop use, so a ref can't be polled
+		//here at the same time eviction's iterator is destroying it. Mirrors evictInBackground's contended-WIP
+		//handling: back off this tick rather than wait if drain/eviction is currently holding it
+		int parallelism = poolConfig.healthCheckParallelism();
+		List<QueuePooledRef<POOLABLE>> candidates;
+		if (WIP.getAndIncrement(this) == 0) {
+			candidates = new ArrayList<>(parallelism);
+			for (int i = 0; i < parallelism; i++) {
+				QueuePooledRef<POOLABLE> ref = idleResourceLeastRecentlyUsed ? e.pollFirst() : e.pollLast();
+				if (ref == null) {
+					break;
+				}
+				decrementIdle();
+				candidates.add(ref);
+			}
+			if (WIP.decrementAndGet(this) > 0) {
+				drainLoop();
+			}
+		}
+		else {
+			//lost the race for WIP to eviction/drain: back off, try again next tick
+			candidates = Collections.emptyList();
+		}
+
+		if (candidates.isEmpty()) {
+			HEALTH_CHECK_WIP.set(this, 0);
+			scheduleHealthCheck();
+			return;
+		}
+
+		//tracked so disposeLater() can still destroy these if their individual check never resolves (see field javadoc)
+		Set<QueuePooledRef<POOLABLE>> inFlight = ConcurrentHashMap.newKeySet(candidates.size());
+		inFlight.addAll(candidates);
+		this.healthCheckSweepCandidates = inFlight;
+
+		this.healthCheckSweepSubscription = Flux.fromIterable(candidates)
+				.flatMap(this::healthCheckOne, parallelism)
+				.reduce(false, (anyDestroyed, destroyed) -> anyDestroyed || destroyed)
+				.doFinally(sig -> {
+					this.healthCheckSweepCandidates = null;
+					HEALTH_CHECK_WIP.set(this, 0);
+					scheduleHealthCheck();
+				})
+				.subscribe(anyDestroyed -> {
+					if (anyDestroyed) {
+						//best effort refill toward the configured minimum size
+						warmup().subscribe(count -> {},
+								warmupError -> this.logger.warn("Error while warming up pool after background health check:", warmupError));
+					}
+				}, error -> this.logger.warn("Error during background health check:", error));
+
+		//registration above isn't linearized with disposeLater(): if it ran its snapshot-and-cleanup pass in
+		//the gap between popping these candidates and finishing registration, it would never see them again.
+		//isDisposed() is a one-way transition, so checking it here reliably catches that and lets us clean up
+		if (isDisposed()) {
+			//capture before disposing the subscription: cancelling it runs doFinally synchronously, which
+			//would otherwise clear healthCheckSweepCandidates before we get to read it
+			Set<QueuePooledRef<POOLABLE>> stillInFlight = this.healthCheckSweepCandidates;
+			Disposable sub = this.healthCheckSweepSubscription;
+			if (sub != null) {
+				sub.dispose();
+			}
+			if (stillInFlight != null) {
+				for (QueuePooledRef<POOLABLE> ref : stillInFlight) {
+					//markDestroy is a CAS: safe even if this ref's check legitimately resolved and is
+					//concurrently going through reofferOrDestroy right now
+					if (ref.markDestroy()) {
+						destroyPoolable(ref).subscribe(v -> {},
+								destroyError -> this.logger.warn("Error while destroying resource after pool was disposed during health check sweep registration:", destroyError));
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * @return a {@link Mono} emitting {@code true} if the resource was destroyed, {@code false} if put back
+	 */
+	Mono<Boolean> healthCheckOne(QueuePooledRef<POOLABLE> ref) {
+		Duration timeout = poolConfig.healthCheckTimeout();
+		Mono<Boolean> check;
+		try {
+			check = Mono.from(poolConfig.healthCheck().apply(ref.poolable, ref));
+		}
+		catch (Throwable healthCheckError) {
+			check = Mono.error(healthCheckError);
+		}
+		if (!timeout.isZero()) {
+			check = check.timeout(timeout, Mono.just(Boolean.FALSE), poolConfig.healthCheckInBackgroundScheduler());
+		}
+		return check.defaultIfEmpty(Boolean.TRUE)
+		            .onErrorReturn(Boolean.FALSE)
+		            .map(healthy -> reofferOrDestroy(ref, healthy));
+	}
+
+	private boolean reofferOrDestroy(QueuePooledRef<POOLABLE> ref, boolean healthy) {
+		//must happen before reoffering/destroying below (see healthCheckSweepCandidates javadoc)
+		Set<QueuePooledRef<POOLABLE>> inFlight = this.healthCheckSweepCandidates;
+		if (inFlight != null) {
+			inFlight.remove(ref);
+		}
+
+		@SuppressWarnings("unchecked")
+		Deque<QueuePooledRef<POOLABLE>> irq = IDLE_RESOURCES.get(this);
+		if (healthy && irq != null) {
+			//offer to the end opposite where sweeps consume from, so successive sweeps rotate through the
+			//whole idle set instead of re-picking the same resource(s)
+			boolean added = idleResourceLeastRecentlyUsed ? irq.offerLast(ref) : irq.offerFirst(ref);
+			if (added) {
+				incrementIdle();
+			}
+			drain();
+			if (isDisposed() && ref.markDestroy()) {
+				if (added) {
+					decrementIdle();
+				}
+				destroyPoolable(ref).subscribe(v -> {},
+						destroyError -> this.logger.warn("Error while destroying resource after background health check:", destroyError));
+				return true;
+			}
+        }
+		else {
+			if (ref.markDestroy()) {
+				destroyPoolable(ref).subscribe(v -> {},
+						destroyError -> this.logger.warn("Error while destroying resource in background health check:", destroyError));
+				return true;
+			}
+        }
+        return false;
+    }
+
 	@Override
 	public Mono<Void> disposeLater() {
 		return Mono.defer(() -> {
@@ -186,9 +369,19 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 			@SuppressWarnings("unchecked") ConcurrentLinkedDeque<Borrower<POOLABLE>> q =
 					PENDING.getAndSet(this, TERMINATED);
 			if (q != TERMINATED) {
+				//read before disposing healthCheckSweepSubscription below, which clears this field via doFinally
+				Set<QueuePooledRef<POOLABLE>> inFlightHealthCheck = this.healthCheckSweepCandidates;
+
 				//stop reaper thread
 				if (this.evictionTask != null) {
 					this.evictionTask.dispose();
+				}
+				if (this.healthCheckTask != null) {
+					this.healthCheckTask.dispose();
+				}
+				//cancels the sweep, but doesn't run reofferOrDestroy, so inFlightHealthCheck still needs handling below
+				if (this.healthCheckSweepSubscription != null) {
+					this.healthCheckSweepSubscription.dispose();
 				}
 
 				Borrower<POOLABLE> p;
@@ -201,17 +394,31 @@ public class SimpleDequePool<POOLABLE> extends AbstractPool<POOLABLE> {
 				@SuppressWarnings("unchecked")
 				Queue<QueuePooledRef<POOLABLE>> e =
 						IDLE_RESOURCES.getAndSet(this, null);
-				if (e != null) {
+
+				if (e != null || inFlightHealthCheck != null) {
 					Mono<Void> destroyMonos = Mono.empty();
-					while (!e.isEmpty()) {
-						QueuePooledRef<POOLABLE> ref = e.poll();
-						if (ref.markDestroy()) {
-							decrementIdle();
-							destroyMonos = destroyMonos.and(destroyPoolable(ref));
+					if (e != null) {
+						//poll-until-null, not "while(!isEmpty()) poll()": a concurrent health check sweep can
+						//still be polling this same deque, so isEmpty()+poll() can't be treated as atomic
+						QueuePooledRef<POOLABLE> ref;
+						while ((ref = e.poll()) != null) {
+							if (ref.markDestroy()) {
+								decrementIdle();
+								destroyMonos = destroyMonos.and(destroyPoolable(ref));
+							}
+						}
+						//we're not setting IDLE_SIZE to zero here on purpose, as competing
+						//markDestroy might happen concurrently which would bring it below 0
+					}
+					if (inFlightHealthCheck != null) {
+						for (QueuePooledRef<POOLABLE> ref : inFlightHealthCheck) {
+							//markDestroy is a CAS: safe even if reofferOrDestroy concurrently wins the race
+							//for this same ref (eg. the check resolved right as dispose was happening)
+							if (ref.markDestroy()) {
+								destroyMonos = destroyMonos.and(destroyPoolable(ref));
+							}
 						}
 					}
-					//we're not setting IDLE_SIZE to zero here on purpose, as competing
-					//markDestroy might happen concurrently which would bring it below 0
 					return destroyMonos;
 				}
 			}

--- a/reactor-pool/src/test/java/reactor/pool/PoolBuilderTest.java
+++ b/reactor-pool/src/test/java/reactor/pool/PoolBuilderTest.java
@@ -30,6 +30,8 @@ import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.PublisherProbe;
 
@@ -160,6 +162,88 @@ class PoolBuilderTest {
 
 		PoolConfig<String> defaults = PoolBuilder.from(Mono.just("test")).buildConfig();
 		assertThat(defaults.maxLifeTimeVariance()).as("default disabled").isZero();
+	}
+
+	@Test
+	void healthCheckDefaults() throws Exception {
+		PoolConfig<String> defaults = PoolBuilder.from(Mono.just("test")).buildConfig();
+
+		assertThat(defaults.healthCheckInBackgroundInterval()).as("default disabled").isEqualTo(Duration.ZERO);
+		assertThat(defaults.healthCheckTimeout()).as("default no timeout").isEqualTo(Duration.ZERO);
+		assertThat(defaults.healthCheckParallelism()).as("default parallelism").isEqualTo(1);
+		assertThat(Mono.from(defaults.healthCheck().apply("test", new TestUtils.TestPooledRef<>("test", 0, 0, 0).metadata())).block())
+				.as("default always healthy").isTrue();
+	}
+
+	@Test
+	void healthCheckCustomized() {
+		BiFunction<String, PooledRefMetadata, Mono<Boolean>> customHealthCheck = (poolable, meta) -> Mono.just(false);
+		PoolConfig<String> config = PoolBuilder.from(Mono.just("test"))
+				.healthCheck(customHealthCheck)
+				.buildConfig();
+
+		assertThat(config.healthCheck()).isSameAs(customHealthCheck);
+	}
+
+	@Test
+	void healthCheckInBackgroundValidation() {
+		PoolConfig<String> disabledExplicitly = PoolBuilder.from(Mono.just("test"))
+				.healthCheckInBackground(Duration.ZERO)
+				.buildConfig();
+		assertThat(disabledExplicitly.healthCheckInBackgroundInterval()).isEqualTo(Duration.ZERO);
+		assertThat(disabledExplicitly.healthCheckInBackgroundScheduler()).isSameAs(Schedulers.immediate());
+
+		PoolConfig<String> disabledMethod = PoolBuilder.from(Mono.just("test"))
+				.healthCheckInBackgroundDisabled()
+				.buildConfig();
+		assertThat(disabledMethod.healthCheckInBackgroundInterval()).isEqualTo(Duration.ZERO);
+
+		PoolConfig<String> enabled = PoolBuilder.from(Mono.just("test"))
+				.healthCheckInBackground(Duration.ofSeconds(5))
+				.buildConfig();
+		assertThat(enabled.healthCheckInBackgroundInterval()).isEqualTo(Duration.ofSeconds(5));
+		assertThat(enabled.healthCheckInBackgroundScheduler()).isSameAs(Schedulers.parallel());
+
+		Scheduler customScheduler = Schedulers.single();
+		PoolConfig<String> customized = PoolBuilder.from(Mono.just("test"))
+				.healthCheckInBackground(Duration.ofSeconds(5), customScheduler)
+				.buildConfig();
+		assertThat(customized.healthCheckInBackgroundScheduler()).isSameAs(customScheduler);
+
+		assertThatNullPointerException()
+				.isThrownBy(() -> PoolBuilder.from(Mono.just("test")).healthCheckInBackground(null));
+		assertThatNullPointerException()
+				.isThrownBy(() -> PoolBuilder.from(Mono.just("test")).healthCheckInBackground(Duration.ofSeconds(5), null));
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> PoolBuilder.from(Mono.just("test")).healthCheckInBackground(Duration.ofSeconds(-1)));
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> PoolBuilder.from(Mono.just("test")).healthCheckInBackground(Duration.ofSeconds(-1), Schedulers.parallel()));
+	}
+
+	@Test
+	void healthCheckTimeoutValidation() {
+		assertThatNullPointerException()
+				.isThrownBy(() -> PoolBuilder.from(Mono.just("test")).healthCheckTimeout(null));
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> PoolBuilder.from(Mono.just("test")).healthCheckTimeout(Duration.ofSeconds(-1)));
+
+		PoolConfig<String> config = PoolBuilder.from(Mono.just("test"))
+				.healthCheckTimeout(Duration.ofSeconds(2))
+				.buildConfig();
+		assertThat(config.healthCheckTimeout()).isEqualTo(Duration.ofSeconds(2));
+	}
+
+	@Test
+	void healthCheckParallelismValidation() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> PoolBuilder.from(Mono.just("test")).healthCheckParallelism(0));
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> PoolBuilder.from(Mono.just("test")).healthCheckParallelism(-1));
+
+		PoolConfig<String> config = PoolBuilder.from(Mono.just("test"))
+				.healthCheckParallelism(4)
+				.buildConfig();
+		assertThat(config.healthCheckParallelism()).isEqualTo(4);
 	}
 
 	@Test

--- a/reactor-pool/src/test/java/reactor/pool/SimpleDequePoolHealthCheckTest.java
+++ b/reactor-pool/src/test/java/reactor/pool/SimpleDequePoolHealthCheckTest.java
@@ -1,0 +1,601 @@
+/*
+ * Copyright (c) 2026 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.pool;
+
+import java.time.Duration;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.test.scheduler.VirtualTimeScheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the background async health check feature added for
+ * <a href="https://github.com/reactor/reactor-pool/issues/285">reactor-pool#285</a>.
+ */
+class SimpleDequePoolHealthCheckTest {
+
+	@Test
+	void disabledByDefaultNeverInvokesHealthCheck() {
+		AtomicInteger invocations = new AtomicInteger();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .sizeBetween(1, 1)
+				           .healthCheck((s, meta) -> {
+					           invocations.incrementAndGet();
+					           return Mono.just(true);
+				           })
+				           .buildConfig());
+
+		assertThat(pool.healthCheckTask).as("no task scheduled").isNotNull();
+		assertThat(pool.healthCheckTask.isDisposed()).as("no-op disposable").isTrue();
+
+		pool.warmup().block();
+		vts.advanceTimeBy(Duration.ofDays(1));
+
+		assertThat(invocations).as("health check never invoked").hasValue(0);
+	}
+
+	@Test
+	void healthyResourceStaysIdleAndIsNotReallocated() {
+		AtomicInteger allocations = new AtomicInteger();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.fromCallable(() -> "resource-" + allocations.incrementAndGet()))
+				           .sizeBetween(1, 1)
+				           .healthCheck((s, meta) -> Mono.just(true))
+				           .healthCheckInBackground(Duration.ofSeconds(10), vts)
+				           .buildConfig());
+
+		pool.warmup().block();
+		assertThat(pool.idleSize()).isEqualTo(1);
+		assertThat(allocations).hasValue(1);
+
+		vts.advanceTimeBy(Duration.ofSeconds(10));
+
+		assertThat(pool.idleSize()).as("still idle after healthy check").isEqualTo(1);
+		assertThat(allocations).as("resource wasn't recreated").hasValue(1);
+	}
+
+	@Test
+	void unhealthyResourceIsDestroyedAndPoolIsBackfilled() {
+		AtomicInteger allocations = new AtomicInteger();
+		AtomicInteger destructions = new AtomicInteger();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.fromCallable(() -> "resource-" + allocations.incrementAndGet()))
+				           .sizeBetween(1, 1)
+				           .destroyHandler(s -> Mono.fromRunnable(destructions::incrementAndGet))
+				           .healthCheck((s, meta) -> Mono.just(false))
+				           .healthCheckInBackground(Duration.ofSeconds(10), vts)
+				           .buildConfig());
+
+		pool.warmup().block();
+		assertThat(allocations).hasValue(1);
+
+		vts.advanceTimeBy(Duration.ofSeconds(10));
+
+		assertThat(destructions).as("unhealthy resource destroyed").hasValue(1);
+		assertThat(allocations).as("pool backfilled to minimum size").hasValue(2);
+		assertThat(pool.idleSize()).as("backfilled resource is idle").isEqualTo(1);
+	}
+
+	/**
+	 * Port of HikariCP's {@code TestConnections#testKeepalive2}: it's not enough that internal counters/idleSize
+	 * look right after an unhealthy resource is destroyed, a caller that acquires afterward must observe a
+	 * genuinely different (fresh) instance, never the one that failed its health check.
+	 */
+	@Test
+	void nextAcquireAfterUnhealthyDestroyGetsAFreshInstanceNotTheDeadOne() {
+		AtomicInteger allocations = new AtomicInteger();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.fromCallable(() -> "resource-" + allocations.incrementAndGet()))
+				           .sizeBetween(1, 1)
+				           .healthCheck((s, meta) -> Mono.just(false))
+				           .healthCheckInBackground(Duration.ofSeconds(10), vts)
+				           .buildConfig());
+
+		pool.warmup().block();
+		PooledRef<String> original = pool.acquire().block();
+		assertThat(original).isNotNull();
+		original.release().block();
+		assertThat(original.poolable()).isEqualTo("resource-1");
+
+		vts.advanceTimeBy(Duration.ofSeconds(10));
+
+		PooledRef<String> replacement = pool.acquire().block();
+		assertThat(replacement).isNotNull();
+		assertThat(replacement.poolable())
+				.as("acquirer gets the freshly backfilled resource, never the dead one")
+				.isNotEqualTo(original.poolable())
+				.isEqualTo("resource-2");
+	}
+
+	@Test
+	void resourceUnderHealthCheckIsNotConcurrentlyAcquirable() {
+		Sinks.One<Boolean> healthCheckSink = Sinks.one();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("the-one-resource"))
+				           .sizeBetween(1, 1)
+				           .healthCheck((s, meta) -> healthCheckSink.asMono())
+				           .healthCheckInBackground(Duration.ofSeconds(10), vts)
+				           .buildConfig());
+
+		pool.warmup().block();
+		assertThat(pool.idleSize()).isEqualTo(1);
+
+		//trigger the sweep: the resource is popped out of idleResources and the (still pending) check subscribed
+		vts.advanceTimeBy(Duration.ofSeconds(10));
+		assertThat(pool.idleSize()).as("resource removed from idle while under test").isEqualTo(0);
+
+		AtomicReference<PooledRef<String>> acquired = new AtomicReference<>();
+		pool.acquire().subscribe(acquired::set);
+
+		assertThat(acquired).as("acquire cannot be served while resource is under health check").hasValue(null);
+		assertThat(pool.pendingAcquireSize()).as("acquire is queued as pending").isEqualTo(1);
+
+		//now let the health check resolve as healthy
+		healthCheckSink.tryEmitValue(true);
+
+		assertThat(acquired.get()).as("pending acquire is served with the resource once healthy").isNotNull();
+		assertThat(acquired.get().poolable()).isEqualTo("the-one-resource");
+		assertThat(pool.pendingAcquireSize()).isEqualTo(0);
+	}
+
+	@Test
+	void timeoutCausesResourceToBeTreatedAsUnhealthy() {
+		AtomicInteger destructions = new AtomicInteger();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .sizeBetween(1, 1)
+				           .destroyHandler(s -> Mono.fromRunnable(destructions::incrementAndGet))
+				           .healthCheck((s, meta) -> Mono.never()) //never resolves on its own
+				           .healthCheckTimeout(Duration.ofSeconds(1))
+				           .healthCheckInBackground(Duration.ofSeconds(10), vts)
+				           .buildConfig());
+
+		pool.warmup().block();
+
+		vts.advanceTimeBy(Duration.ofSeconds(10));
+		assertThat(destructions).as("not yet timed out").hasValue(0);
+
+		vts.advanceTimeBy(Duration.ofSeconds(1));
+		assertThat(destructions).as("destroyed after timeout").hasValue(1);
+	}
+
+	@Test
+	void errorFromHealthCheckIsTreatedAsUnhealthy() {
+		AtomicInteger destructions = new AtomicInteger();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .sizeBetween(1, 1)
+				           .destroyHandler(s -> Mono.fromRunnable(destructions::incrementAndGet))
+				           .healthCheck((s, meta) -> Mono.error(new IllegalStateException("boom")))
+				           .healthCheckInBackground(Duration.ofSeconds(10), vts)
+				           .buildConfig());
+
+		pool.warmup().block();
+
+		vts.advanceTimeBy(Duration.ofSeconds(10));
+
+		assertThat(destructions).as("errored check treated as unhealthy").hasValue(1);
+	}
+
+	@Test
+	void healthCheckParallelismBoundsResourcesPulledPerSweep() {
+		AtomicInteger concurrentChecks = new AtomicInteger();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .sizeBetween(3, 3)
+				           .healthCheck((s, meta) -> {
+					           concurrentChecks.incrementAndGet();
+					           return Mono.never(); //never resolves, so we can observe the in-flight state
+				           })
+				           .healthCheckParallelism(2)
+				           .healthCheckInBackground(Duration.ofSeconds(10), vts)
+				           .buildConfig());
+
+		pool.warmup().block();
+		assertThat(pool.idleSize()).isEqualTo(3);
+
+		vts.advanceTimeBy(Duration.ofSeconds(10));
+
+		assertThat(concurrentChecks).as("only up to parallelism checks started").hasValue(2);
+		assertThat(pool.idleSize()).as("remaining resource still idle/available").isEqualTo(1);
+	}
+
+	/**
+	 * With parallelism 1 (or more generally parallelism &lt; idle count), a sweep only checks a subset of the
+	 * idle resources at a time. A healthy resource must be rotated to the opposite end of the idle deque from
+	 * the one sweeps consume from, otherwise successive sweeps keep re-picking the same resource(s) and the
+	 * rest of the idle set is never checked. This asserts full round-robin coverage across several sweeps,
+	 * including wrap-around back to the first resource.
+	 */
+	@Test
+	void repeatedSweepsRotateThroughAllIdleResourcesInsteadOfRecheckingTheSameOne() {
+		List<String> checkedOrder = new CopyOnWriteArrayList<>();
+		AtomicInteger allocations = new AtomicInteger();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.fromCallable(() -> "resource-" + allocations.incrementAndGet()))
+				           .sizeBetween(3, 3)
+				           .healthCheck((s, meta) -> {
+					           checkedOrder.add(s);
+					           return Mono.just(true);
+				           })
+				           .healthCheckParallelism(1)
+				           .healthCheckInBackground(Duration.ofSeconds(10), vts)
+				           .buildConfig());
+
+		pool.warmup().block();
+		assertThat(pool.idleSize()).isEqualTo(3);
+
+		//4 sweeps: one full rotation over the 3 idle resources, plus one to prove it wraps back around
+		for (int i = 0; i < 4; i++) {
+			vts.advanceTimeBy(Duration.ofSeconds(10));
+		}
+
+		assertThat(checkedOrder)
+				.as("every idle resource gets checked in turn, then wraps back around, instead of only the first ever being revisited")
+				.containsExactly("resource-1", "resource-2", "resource-3", "resource-1");
+		assertThat(allocations).as("no resource was destroyed/reallocated, all checks were healthy").hasValue(3);
+		assertThat(pool.idleSize()).as("all resources remain idle").isEqualTo(3);
+	}
+
+	@Test
+	void sweepBacksOffWhenThereArePendingAcquires() {
+		AtomicInteger invocations = new AtomicInteger();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .sizeBetween(1, 1)
+				           .healthCheck((s, meta) -> {
+					           invocations.incrementAndGet();
+					           return Mono.just(true);
+				           })
+				           .healthCheckInBackground(Duration.ofSeconds(10), vts)
+				           .buildConfig());
+
+		pool.warmup().block();
+		pool.pendingSize = 1; //simulate an in-flight pending acquire, same-package test access
+
+		vts.advanceTimeBy(Duration.ofSeconds(10));
+
+		assertThat(invocations).as("sweep backed off due to pool activity").hasValue(0);
+		assertThat(pool.idleSize()).as("idle resource untouched").isEqualTo(1);
+	}
+
+	@Test
+	void disposeLaterCancelsHealthCheckTask() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .healthCheck((s, meta) -> Mono.just(true))
+				           .healthCheckInBackground(Duration.ofSeconds(10), vts)
+				           .buildConfig());
+
+		assertThat(pool.healthCheckTask).isNotNull();
+		assertThat(pool.healthCheckTask.isDisposed()).isFalse();
+
+		pool.disposeLater().block();
+
+		assertThat(pool.healthCheckTask.isDisposed()).as("background task cancelled on dispose").isTrue();
+	}
+
+	/**
+	 * A resource pulled out of {@code idleResources} for an in-flight background health check is not tracked
+	 * anywhere else. If the {@link PoolConfig#healthCheck()} publisher never emits (the documented default has
+	 * no timeout) and {@code disposeLater()} is called while the check is still pending, the resource must
+	 * still be destroyed and its allocation permit returned - it must not be silently leaked.
+	 */
+	@Test
+	void disposeLaterDestroysResourceStuckInAnInFlightHealthCheck() {
+		AtomicInteger destructions = new AtomicInteger();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .sizeBetween(1, 1)
+				           .destroyHandler(s -> Mono.fromRunnable(destructions::incrementAndGet))
+				           .healthCheck((s, meta) -> Mono.never()) //never resolves, no timeout configured
+				           .healthCheckInBackground(Duration.ofSeconds(10), vts)
+				           .buildConfig());
+
+		pool.warmup().block();
+		vts.advanceTimeBy(Duration.ofSeconds(10));
+		assertThat(pool.idleSize()).as("resource pulled out for the (hanging) check").isEqualTo(0);
+
+		pool.disposeLater().block();
+
+		assertThat(destructions)
+				.as("resource stuck in an in-flight health check is still destroyed on dispose, not leaked")
+				.hasValue(1);
+	}
+
+	/**
+	 * Disposing an in-flight sweep's subscription runs its {@code doFinally} synchronously, which used to call
+	 * {@code scheduleHealthCheck()} unconditionally - re-arming a brand new {@code healthCheckTask} right after
+	 * {@code disposeLater()} had just disposed the previous one. That leaves the pool with a live, un-disposed
+	 * background task after shutdown.
+	 */
+	@Test
+	void disposingAnInFlightSweepDoesNotRescheduleAfterDispose() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .sizeBetween(1, 1)
+				           .healthCheck((s, meta) -> Mono.never()) //never resolves: sweep stays in flight
+				           .healthCheckInBackground(Duration.ofSeconds(10), vts)
+				           .buildConfig());
+
+		pool.warmup().block();
+		vts.advanceTimeBy(Duration.ofSeconds(10));
+		assertThat(pool.healthCheckSweepSubscription).as("sweep is in flight").isNotNull();
+
+		pool.disposeLater().block();
+
+		assertThat(pool.healthCheckTask)
+				.as("no new task scheduled behind disposeLater()'s back")
+				.isNotNull();
+		assertThat(pool.healthCheckTask.isDisposed())
+				.as("the task disposeLater() disposed must stay disposed, not be replaced by a fresh scheduled one")
+				.isTrue();
+	}
+
+	/**
+	 * {@code healthCheckInBackground()}'s early backoff (pool activity / lost the WIP race) and empty-candidate
+	 * paths also call {@code scheduleHealthCheck()}, without themselves checking disposal - if a tick happens
+	 * to reach either path in the (narrow, real) window where the pool has just been disposed, they'd re-arm a
+	 * task the same way the doFinally path used to. The guard belongs inside {@code scheduleHealthCheck()}
+	 * itself so every caller - present or future - is covered unconditionally, not just the doFinally one.
+	 */
+	@Test
+	void scheduleHealthCheckNeverArmsANewTaskOnceDisposed() {
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.just("example"))
+				           .healthCheckInBackground(Duration.ofSeconds(10), vts)
+				           .buildConfig());
+
+		pool.disposeLater().block();
+		assertThat(pool.healthCheckTask.isDisposed()).as("disposed by disposeLater()").isTrue();
+
+		//simulates any caller (backoff/empty-candidate paths, doFinally, or a future one) reaching
+		//scheduleHealthCheck() after the pool is already disposed
+		pool.scheduleHealthCheck();
+
+		assertThat(pool.healthCheckTask)
+				.as("still the same already-disposed task disposeLater() left behind")
+				.isNotNull();
+		assertThat(pool.healthCheckTask.isDisposed())
+				.as("scheduleHealthCheck() must refuse to arm a new task once the pool is disposed, regardless of caller")
+				.isTrue();
+	}
+
+	/**
+	 * {@code healthCheckSweepCandidates} must only ever contain refs whose check hasn't resolved yet. If one
+	 * candidate in a batch resolves healthy (and gets reoffered, then acquired by a live borrower) while another
+	 * candidate from the *same* batch is still pending, {@code disposeLater()} must not destroy the acquired one
+	 * just because the batch as a whole isn't finished - that would destroy a resource out from under the
+	 * borrower currently holding it, without their knowledge.
+	 */
+	@Test
+	void disposeDoesNotDestroyAnAlreadyAcquiredResourceFromTheSameHealthCheckBatch() {
+		List<String> destroyedPoolables = new CopyOnWriteArrayList<>();
+		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
+		SimpleDequePool<String> pool = new SimpleDequePool<>(
+				PoolBuilder.from(Mono.fromCallable(new AtomicInteger()::incrementAndGet).map(n -> "resource-" + n))
+				           .sizeBetween(2, 2)
+				           .destroyHandler(s -> Mono.fromRunnable(() -> destroyedPoolables.add(s)))
+				           //resource-1 resolves immediately as healthy, resource-2 hangs forever: both are
+				           //part of the same sweep batch (healthCheckParallelism(2))
+				           .healthCheck((s, meta) -> "resource-1".equals(s) ? Mono.just(true) : Mono.never())
+				           .healthCheckParallelism(2)
+				           .healthCheckInBackground(Duration.ofSeconds(10), vts)
+				           .buildConfig());
+
+		pool.warmup().block();
+		vts.advanceTimeBy(Duration.ofSeconds(10));
+
+		//resource-1's check already resolved and was reoffered; resource-2's check is still pending
+		assertThat(pool.idleSize()).as("resource-1 reoffered, resource-2 still checked out").isEqualTo(1);
+
+		PooledRef<String> acquired = pool.acquire().block();
+		assertThat(acquired).isNotNull();
+		assertThat(acquired.poolable()).as("the only idle resource is the one that already resolved").isEqualTo("resource-1");
+
+		pool.disposeLater().block();
+
+		assertThat(destroyedPoolables)
+				.as("acquired resource must not be destroyed while still held by its borrower")
+				.doesNotContain("resource-1");
+		assertThat(destroyedPoolables)
+				.as("the genuinely still-hanging resource is destroyed by dispose as usual")
+				.containsExactly("resource-2");
+
+		acquired.release().block();
+		assertThat(destroyedPoolables)
+				.as("once released (pool already disposed), the resource is cleaned up through the normal release path")
+				.contains("resource-1");
+	}
+
+	/**
+	 * Background eviction ({@code evictInBackground()}) and the background health check sweep
+	 * ({@code healthCheckInBackground()}) both mutate {@code idleResources}/{@code idleSize}. Without sharing the
+	 * pool's {@code WIP} exclusion guard, a ref could be polled by the health check sweep at the same time
+	 * eviction's iterator is independently destroying it: both sides would {@code decrementIdle()} for what is
+	 * really a single removal, and the health check could later re-offer a ref that eviction already destroyed.
+	 * <p>
+	 * Runs both reapers from separate threads, synchronized to start together via a {@link CyclicBarrier} to
+	 * maximize contention on the same set of idle refs, repeated over many iterations. Regardless of which
+	 * reaper "wins" a given ref on a given run (the outcome is legitimately nondeterministic), the invariants
+	 * below must always hold.
+	 */
+	@Test
+	void concurrentEvictionAndHealthCheckDoNotCorruptIdleAccounting() throws Exception {
+		int iterations = 300;
+		int poolSize = 4;
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		try {
+			for (int i = 0; i < iterations; i++) {
+				AtomicInteger destroyCount = new AtomicInteger();
+				List<String> destroyedPoolables = new CopyOnWriteArrayList<>();
+				SimpleDequePool<String> pool = new SimpleDequePool<>(
+						PoolBuilder.from(Mono.fromCallable(() -> "resource-" + System.nanoTime()))
+						           .sizeBetween(poolSize, poolSize)
+						           //evict everything: maximizes contention against the health check sweep below
+						           .evictionPredicate((s, meta) -> true)
+						           //always healthy: any ref the sweep grabs gets re-offered, contending with eviction
+						           .healthCheck((s, meta) -> Mono.just(true))
+						           .healthCheckParallelism(poolSize)
+						           .destroyHandler(s -> Mono.fromRunnable(() -> {
+							           destroyCount.incrementAndGet();
+							           destroyedPoolables.add(s);
+						           }))
+						           .buildConfig());
+				pool.warmup().block();
+				assertThat(pool.idleSize()).isEqualTo(poolSize);
+
+				CyclicBarrier barrier = new CyclicBarrier(2);
+				Runnable runEviction = () -> {
+					awaitBarrier(barrier);
+					pool.evictInBackground();
+				};
+				Runnable runHealthCheck = () -> {
+					awaitBarrier(barrier);
+					pool.healthCheckInBackground();
+				};
+
+				Future<?> evictionFuture = executor.submit(runEviction);
+				Future<?> healthCheckFuture = executor.submit(runHealthCheck);
+				evictionFuture.get(5, TimeUnit.SECONDS);
+				healthCheckFuture.get(5, TimeUnit.SECONDS);
+
+				int finalIdleSize = pool.idleSize();
+				int finalDestroyCount = destroyCount.get();
+
+				assertThat(finalIdleSize).as("iteration %d: idleSize never goes negative", i).isGreaterThanOrEqualTo(0);
+				assertThat(finalIdleSize + finalDestroyCount)
+						.as("iteration %d: every resource is either still idle or destroyed exactly once, no leaks/no double-counting", i)
+						.isEqualTo(poolSize);
+				assertThat(destroyedPoolables)
+						.as("iteration %d: no resource destroyed more than once", i)
+						.doesNotHaveDuplicates();
+
+				Deque<SimpleDequePool.QueuePooledRef<String>> remainingIdle = pool.idleResources;
+				assertThat(remainingIdle).isNotNull();
+				for (SimpleDequePool.QueuePooledRef<String> ref : remainingIdle) {
+					assertThat(destroyedPoolables)
+							.as("iteration %d: an already-destroyed resource must never reappear as idle/available", i)
+							.doesNotContain(ref.poolable);
+				}
+
+				pool.disposeLater().block();
+			}
+		}
+		finally {
+			executor.shutdownNow();
+		}
+	}
+
+	/**
+	 * Sweep registration ({@code healthCheckSweepCandidates}/{@code healthCheckSweepSubscription}) is not
+	 * linearized with {@code disposeLater()}: candidates are popped out of {@code idleResources} before those
+	 * fields are set. If {@code disposeLater()} runs its entire snapshot-and-cleanup pass (reads
+	 * {@code healthCheckSweepCandidates} as still null, detaches an {@code idleResources} that no longer
+	 * contains the already-popped candidates) inside that gap, the popped refs would never be found by either
+	 * cleanup path and leak forever if their check never resolves - since a second {@code disposeLater()} call
+	 * is a no-op once the pool is already terminated.
+	 * <p>
+	 * Runs {@code healthCheckInBackground()} and {@code disposeLater()} from separate threads, synchronized via
+	 * a {@link CyclicBarrier} to maximize the chance of {@code disposeLater()} landing inside the registration
+	 * gap, repeated over many iterations. Every resource must always end up destroyed exactly once - regardless
+	 * of which thread "wins" - never left permanently unaccounted for.
+	 */
+	@Test
+	void disposeDuringSweepRegistrationNeverLeaksTheCandidates() throws Exception {
+		int iterations = 2000;
+		int poolSize = 4;
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		try {
+			for (int i = 0; i < iterations; i++) {
+				List<String> destroyedPoolables = new CopyOnWriteArrayList<>();
+				SimpleDequePool<String> pool = new SimpleDequePool<>(
+						PoolBuilder.from(Mono.fromCallable(() -> "resource-" + System.nanoTime()))
+						           .sizeBetween(poolSize, poolSize)
+						           //never resolves: maximizes the time a leaked ref would stay undestroyed,
+						           //and keeps healthCheckSweepSubscription alive/cancellable for longer
+						           .healthCheck((s, meta) -> Mono.never())
+						           .healthCheckParallelism(poolSize)
+						           .destroyHandler(s -> Mono.fromRunnable(() -> destroyedPoolables.add(s)))
+						           .buildConfig());
+				pool.warmup().block();
+				assertThat(pool.idleSize()).isEqualTo(poolSize);
+
+				CyclicBarrier barrier = new CyclicBarrier(2);
+				Runnable runHealthCheck = () -> {
+					awaitBarrier(barrier);
+					pool.healthCheckInBackground();
+				};
+				Runnable runDispose = () -> {
+					awaitBarrier(barrier);
+					pool.disposeLater().block();
+				};
+
+				Future<?> healthCheckFuture = executor.submit(runHealthCheck);
+				Future<?> disposeFuture = executor.submit(runDispose);
+				healthCheckFuture.get(5, TimeUnit.SECONDS);
+				disposeFuture.get(5, TimeUnit.SECONDS);
+
+				assertThat(destroyedPoolables)
+						.as("iteration %d: every resource destroyed exactly once, none leaked by racing sweep registration against dispose", i)
+						.hasSize(poolSize)
+						.doesNotHaveDuplicates();
+			}
+		}
+		finally {
+			executor.shutdownNow();
+		}
+	}
+
+	private static void awaitBarrier(CyclicBarrier barrier) {
+		try {
+			barrier.await(5, TimeUnit.SECONDS);
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+}


### PR DESCRIPTION
Resolves: https://github.com/reactor/reactor-pool/issues/285

I did my best to take into account the concerns raised in https://github.com/r2dbc/r2dbc-pool/issues/187 and I also ported a relevant test from HikariCP just to be doubly sure that everything works as expected.

The currently existing `evictionPredicate` wasn't suitable since it had a `BiPredicate` signature which is synchronous/non blocking so a new one had to be made (i.e. r2dbc-pool needs to do async requests against databases). The implementation works on the currently existing `SimpleDequePool` by adding health check ticks, making sure that while a resource is being checked it cannot be acquired (as well as other edge cases).

The expected configuration knobs have been added, I also added a `TODO//` to remind ourselves to remove unnecessary overrides when v2 gets released.

While working on this I have found a race condition which while it may not be problematic before, is now due to the newly added healthcheck i.e., previously there was 

```java
while (!e.isEmpty()) {
    QueuePooledRef<POOLABLE> ref = e.poll();
    if (ref.markDestroy()) {   // <- NPE here
        ...
    }
}
```

Individually `e.isEmpty()` and `e.poll()` are atomic (where `e` is a `ConcurrentLinkedDeque`) but combined in this way they are not, another thread could remove the last element and at the same time `e.poll` is accessed and you would get `null` (causing NPE) and this case happens with the PR's new `healthCheckInBackground()` (which runs in another thread) and it could have also happened with another future feature where another thread would be accessing `e`.